### PR TITLE
[fix] Borrado real de anuncios #107

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,6 @@ gem 'paperclip', '~> 4.0'                           # images
 gem 'delayed_paperclip'                             # images processing in bacground
 gem 'recaptcha', :require => 'recaptcha/rails'      # captcha
 gem 'airbrake'                                      # exception notification
-gem 'paranoia', '~> 2.0'                            # don't really delete a model
 gem 'ipaddress'                                     # ip address validation
 gem 'localeapp'                                     # i18n interface
 gem 'blueprint-rails'                               # blueprint css framework

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,8 +337,6 @@ GEM
       cocaine (~> 0.5.5)
       mime-types
       mimemagic (= 0.3.0)
-    paranoia (2.1.3)
-      activerecord (~> 4.0)
     polyamorous (1.2.0)
       activerecord (>= 3.0)
     rack (1.6.4)
@@ -551,7 +549,6 @@ DEPENDENCIES
   omniauth-facebook
   omniauth-google-oauth2
   paperclip (~> 4.0)
-  paranoia (~> 2.0)
   rails (~> 4.2)
   rails-assets-bootstrap!
   rails-footnotes (~> 4.0)

--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -50,8 +50,6 @@ class Ad < ActiveRecord::Base
 
   default_scope { order('ads.created_at DESC') }
 
-  acts_as_paranoid
-
   has_attached_file :image,
     styles: {thumb: "100x90>"},
     process_in_background: :image 

--- a/db/migrate/20151026224220_remove_paranoia.rb
+++ b/db/migrate/20151026224220_remove_paranoia.rb
@@ -1,0 +1,13 @@
+class RemoveParanoia < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      DELETE FROM ads WHERE deleted_at IS NOT NULL
+    SQL
+
+    remove_column :ads, :deleted_at
+  end
+
+  def down
+    add_column :ads, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151001175712) do
+ActiveRecord::Schema.define(version: 20151026224220) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace",     limit: 255
@@ -39,7 +39,6 @@ ActiveRecord::Schema.define(version: 20151001175712) do
     t.string   "photo",              limit: 100
     t.integer  "status",             limit: 4,                 null: false
     t.integer  "comments_enabled",   limit: 4
-    t.datetime "deleted_at"
     t.datetime "updated_at"
     t.string   "image_file_name",    limit: 255
     t.string   "image_content_type", limit: 255
@@ -49,7 +48,6 @@ ActiveRecord::Schema.define(version: 20151001175712) do
     t.integer  "comments_count",     limit: 4,     default: 0
   end
 
-  add_index "ads", ["deleted_at"], name: "index_ads_on_deleted_at", using: :btree
   add_index "ads", ["status"], name: "index_ads_on_status", using: :btree
   add_index "ads", ["woeid_code"], name: "woeid", using: :btree
 
@@ -100,14 +98,14 @@ ActiveRecord::Schema.define(version: 20151001175712) do
     t.integer  "sender_id",            limit: 4
     t.string   "sender_type",          limit: 255
     t.integer  "conversation_id",      limit: 4
-    t.boolean  "draft",                limit: 1,        default: false
+    t.boolean  "draft",                                 default: false
     t.datetime "updated_at",                                            null: false
     t.datetime "created_at",                                            null: false
     t.integer  "notified_object_id",   limit: 4
     t.string   "notified_object_type", limit: 255
     t.string   "notification_code",    limit: 255
     t.string   "attachment",           limit: 255
-    t.boolean  "global",               limit: 1,        default: false
+    t.boolean  "global",                                default: false
     t.datetime "expires"
   end
 
@@ -120,9 +118,9 @@ ActiveRecord::Schema.define(version: 20151001175712) do
     t.integer  "receiver_id",     limit: 4
     t.string   "receiver_type",   limit: 255
     t.integer  "notification_id", limit: 4,                   null: false
-    t.boolean  "is_read",         limit: 1,   default: false
-    t.boolean  "trashed",         limit: 1,   default: false
-    t.boolean  "deleted",         limit: 1,   default: false
+    t.boolean  "is_read",                     default: false
+    t.boolean  "trashed",                     default: false
+    t.boolean  "deleted",                     default: false
     t.string   "mailbox_type",    limit: 25
     t.datetime "created_at",                                  null: false
     t.datetime "updated_at",                                  null: false
@@ -148,7 +146,7 @@ ActiveRecord::Schema.define(version: 20151001175712) do
     t.text     "body",        limit: 65535,                 null: false
     t.integer  "readed",      limit: 4,     default: 0,     null: false
     t.datetime "updated_at"
-    t.boolean  "is_migrated", limit: 1,     default: false
+    t.boolean  "is_migrated",               default: false
   end
 
   add_index "messages_legacy", ["thread_id"], name: "thread_id", using: :btree

--- a/test/controllers/ads_controller_test.rb
+++ b/test/controllers/ads_controller_test.rb
@@ -108,13 +108,24 @@ class AdsControllerTest < ActionController::TestCase
     assert_redirected_to new_user_session_url
   end
 
-  test "should not destroy ad as normal user" do
+  test "should not destroy non-owned ads as normal user" do
     sign_in @user
     assert_difference('Ad.count', 0) do
       delete :destroy, id: @ad
     end
 
     assert_redirected_to root_path
+  end
+
+  test "should destroy owned ads as normal user" do
+    @ad.user_owner = @user.id
+    @ad.save
+    sign_in @user
+    assert_difference('Ad.count', -1) do
+      delete :destroy, id: @ad
+    end
+
+    assert_redirected_to ads_path
   end
 
   test "should destroy ad as admin user" do


### PR DESCRIPTION
* Elimina la gema "paranoia" y el flag `deleted_at`.
* Añade un test para comprobar el nuevo funcionamiento. Nótese que el
test ya pasa sin los cambios de este commit. Esto es porque paranoia
añade un `default_scope` que descarta los mensajes borrados, con lo que
`Ad.count` no los tiene en cuenta. Si quisiéramos que el test fallara,
podríamos hacer `Ad.unscope.count`, pero he preferido dejarlo en
`Ad.count` por ser consistente con los demás tests.
* La migración incluye una query para eliminar los anuncios con el flag
puesto, pero ojo, __no la he probado__ aunque parece bastante simple.
* El commit incluye algo de "basura" en el esquema: al parecer la última
versión de Rails ya no genera el parámetro (redundante) `limit: 1` para
booleanos.