### PR TITLE
[CSS] Fix home page CSS issue

### DIFF
--- a/app/assets/stylesheets/common.css.sass.erb
+++ b/app/assets/stylesheets/common.css.sass.erb
@@ -646,7 +646,6 @@ dl, dd
   word-break: break-all
   border-bottom: 1px solid #DDD
   h4
-    clear: both
     font-size: 1.4em
     font-weight: bold
 


### PR DESCRIPTION

Buenas!

He observado que me salen las imágenes descolocadas en la portada. Adjunto imagen en la que marco el espacio en blanco "inesperado".

![captura de pantalla de 2016-03-02 11 34 24](https://cloud.githubusercontent.com/assets/2887858/13457982/3fffcfea-e06b-11e5-886b-6a50cdde31f4.png)

Para arreglarlo he desmarcado una propiedad `clear: both`, y quedá así:

![captura de pantalla de 2016-03-02 11 35 28](https://cloud.githubusercontent.com/assets/2887858/13458238/8aed91b2-e06c-11e5-945d-d73379590e0a.png)

Mirando en el código, esta propiedad no está en la rama `master`. Por eso hago esta PR a la rama `production` directamente.