### PR TITLE
Fix words being broken in incorrect places

### DIFF
--- a/app/assets/stylesheets/common.css.sass.erb
+++ b/app/assets/stylesheets/common.css.sass.erb
@@ -643,7 +643,6 @@ dl, dd
   padding-top: 14px
   padding-bottom: 10px
   width: 100%
-  word-break: break-all
   border-bottom: 1px solid #DDD
   h4
     font-size: 1.4em


### PR DESCRIPTION
Arregla bug visual donde las palabras se cortan en lugares incorrectos.

![captura de pantalla de 2016-03-04 11 30 28](https://cloud.githubusercontent.com/assets/2887858/13524989/b0e37a9c-e1fe-11e5-9b65-795993afcff5.png)

vs

![captura de pantalla de 2016-03-04 11 30 36](https://cloud.githubusercontent.com/assets/2887858/13524985/ad21ccec-e1fe-11e5-80be-0ac913dcb7b9.png)