### PR TITLE
Fix activity scopes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ group :development, :test do
   gem 'capybara-webkit'                     # test: features - js: true
   gem 'launchy'                             # test: features - save_and_open_page helper
   gem 'factory_girl_rails', '~> 4.0'        # test: factories
-  gem 'minitest-reporters'                  # test: color output
   gem 'database_cleaner'                    # test: for not having duplicity
   gem 'byebug'                              # dev: debugger
   gem 'spring'                              # dev: speed up things

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,6 @@ GEM
     airbrake (4.3.1)
       builder
       multi_json
-    ansi (1.5.0)
     arbre (1.0.3)
       activesupport (>= 3.0.0)
     arel (6.0.3)
@@ -271,11 +270,6 @@ GEM
       minitest-capybara (~> 0.7.0)
       minitest-metadata (~> 0.5.0)
       minitest-rails (~> 2.1)
-    minitest-reporters (1.1.7)
-      ansi
-      builder
-      minitest (>= 5.0)
-      ruby-progressbar
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -389,7 +383,6 @@ GEM
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     riddle (1.5.12)
-    ruby-progressbar (1.7.5)
     ruby_parser (3.7.2)
       sexp_processor (~> 4.1)
     sass (3.2.19)
@@ -515,7 +508,6 @@ DEPENDENCIES
   mailboxer!
   mailcatcher
   minitest-rails-capybara
-  minitest-reporters
   mysql2 (~> 0.3.18)
   newrelic_rpm
   omniauth

--- a/app/helpers/ad_helper.rb
+++ b/app/helpers/ad_helper.rb
@@ -1,14 +1,6 @@
 # encoding : utf-8
 module AdHelper
 
-  def self.get_users_ranking(limit=20, last_week=false)
-    if last_week
-      User.last_week.order("ads_count DESC").select('username, ads_count, id').limit(limit)
-    else
-      User.order("ads_count DESC").select('username, ads_count, id').limit(limit)
-    end
-  end
-
   def self.get_locations_ranking(limit=20)
     Ad.give.group_by(&:woeid_code).map{ |w,a| [WoeidHelper.convert_woeid_name(w)[:full], w, a.count] }.sort_by{|k| k[2]}.reverse.take(limit) 
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,18 @@ class User < ActiveRecord::Base
 
   scope :last_week, lambda { where("created_at >= :date", :date => 1.week.ago) } 
 
+  scope :top_overall, ->(limit = 20) do
+    select("users.id, users.username, COUNT(ads.id) as n_ads")
+      .joins(:ads)
+      .group("ads.user_owner")
+      .order("n_ads DESC")
+      .limit(limit)
+  end
+
+  scope :top_last_week, ->(limit = 20) do
+    top_overall.where("published_at >= :date", date: 1.week.ago)
+  end
+
   def self.from_omniauth(auth) 
     where(email: auth.info.email).first_or_create do |user|
       user.email = auth.info.email

--- a/app/views/partials/_section_users.html.erb
+++ b/app/views/partials/_section_users.html.erb
@@ -2,10 +2,10 @@
   <h2><%= t('nlt.users_most_active_last_week') %></h2>
   <br>
   <ul>
-    <% AdHelper.get_users_ranking(80, true).each do |u| %>
+    <% User.top_last_week(80).each do |u| %>
       <li>
     <%= link_to listads_user_path u.id do %>
-      <%= u.username %> (<%= u.ads_count %>)
+      <%= u.username %> (<%= u.n_ads %>)
   <% end %>
     </li>
   <% end %>
@@ -16,10 +16,10 @@
   <h2><%= t('nlt.users_most_active_last_week') %></h2>
   <br>
   <ul>
-    <% AdHelper.get_users_ranking(5, true).each do |u| %>
+    <% User.top_last_week(5).each do |u| %>
       <li>
     <%= link_to listads_user_path u.id do %>
-      <%= u.username %> (<%= u.ads_count %>)
+      <%= u.username %> (<%= u.n_ads %>)
   <% end %>
     </li>
   <% end %>
@@ -31,10 +31,10 @@
   <h2><%= t('nlt.users_most_active') %></h2>
   <br>
   <ul>
-    <% AdHelper.get_users_ranking(80).each do |u| %>
+    <% User.top_overall(80).each do |u| %>
       <li>
     <%= link_to listads_user_path u.id do %>
-      <%= u.username %> (<%= u.ads_count %>)
+      <%= u.username %> (<%= u.n_ads %>)
   <% end %>
     </li>
   <% end %>
@@ -45,10 +45,10 @@
   <h2><%= t('nlt.users_most_active') %></h2>
   <br>
   <ul>
-    <% AdHelper.get_users_ranking(20).each do |u| %>
+    <% User.top_overall(20).each do |u| %>
       <li>
     <%= link_to listads_user_path u.id do %>
-      <%= u.username %> (<%= u.ads_count %>)
+      <%= u.username %> (<%= u.n_ads %>)
   <% end %>
     </li>
   <% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,6 @@ NolotiroOrg::Application.configure do
   # for devise
   config.action_mailer.default_url_options = { :host => 'localhost:3000' }
 
+  # Set to :debug to see everything in the log.
+  config.log_level = :debug
 end

--- a/test/factories/ad.rb
+++ b/test/factories/ad.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
     status 1
     woeid_code 766273
     ip "28.3.2.4"
-    created_at "2013-11-01T10:41:00+01:00" 
+    created_at { Time.zone.now }
     user
     published_at { created_at }
   end

--- a/test/helpers/ad_helper_test.rb
+++ b/test/helpers/ad_helper_test.rb
@@ -4,14 +4,8 @@ class AdHelperTest < ActionView::TestCase
   include AdHelper
 
   setup do
-    @ad = FactoryGirl.create(:ad)
+    FactoryGirl.create(:ad)
     Rails.cache.clear
-  end
-
-  test "should get user ranking" do
-    users = AdHelper.get_users_ranking
-    assert_equal(@ad.user.username, users[0].username)
-    assert_equal(1, users[0].ads_count)
   end
 
   test "should get locations ranking" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -83,3 +83,52 @@ class UserTest < ActiveSupport::TestCase
   end
 
 end
+
+class UserScopesTest < ActiveSupport::TestCase
+  setup do
+    3.times { FactoryGirl.create(:ad, user: user1) }
+    2.times { FactoryGirl.create(:ad, user: user2) }
+  end
+
+  test "top overall gives all time top ad publishers" do
+    FactoryGirl.create(:ad, user: user3)
+
+    results = User.top_overall
+
+    assert_equal(3, results.length)
+
+    assert_count(results.first, user1.id, user1.username, 3)
+    assert_count(results.second, user2.id, user2.username, 2)
+    assert_count(results.third, user3.id, user3.username, 1)
+  end
+
+  test "top last week gives last week's top publishers" do
+    FactoryGirl.create(:ad, user: user3, published_at: 8.days.ago)
+
+    results = User.top_last_week
+
+    assert_equal(2, results.length)
+    assert_count(results.first, user1.id, user1.username, 3)
+    assert_count(results.second, user2.id, user2.username, 2)
+  end
+
+  private
+
+  def assert_count(user, id, username, n_ads)
+    assert_equal id, user.id
+    assert_equal username, user.username
+    assert_equal n_ads, user.n_ads
+  end
+
+  def user1
+    @user1 ||= FactoryGirl.create(:user, username: 'user1')
+  end
+
+  def user2
+    @user2 ||= FactoryGirl.create(:user, username: 'user2')
+  end
+
+  def user3
+    @user3 ||= FactoryGirl.create(:user, username: 'user3')
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,15 +1,12 @@
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
-require 'minitest/spec'
+
 require 'minitest/pride'
 require 'minitest/rails/capybara'
-include Warden::Test::Helpers
 
 Capybara.javascript_driver = :webkit
-Warden.test_mode!
 DatabaseCleaner.strategy = :transaction
-#DatabaseCleaner.strategy = :truncation
 
 # Ensure sphinx directories exist for the test environment
 ThinkingSphinx::Test.init

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,8 +13,7 @@ DatabaseCleaner.strategy = :transaction
 # Ensure sphinx directories exist for the test environment
 ThinkingSphinx::Test.init
 
-class ActionController::TestCase
-  include Devise::TestHelpers
+class ActiveSupport::TestCase
   include FactoryGirl::Syntax::Methods
 
   def setup
@@ -26,6 +25,10 @@ class ActionController::TestCase
   def teardown
     DatabaseCleaner.clean
   end
+end
+
+class ActionController::TestCase
+  include Devise::TestHelpers
 end
 
 class ActionDispatch::Routing::RouteSet

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,7 @@
 ENV["RAILS_ENV"] ||= "test"
-require File.expand_path('../../config/environment', __FILE__)
+
+require_relative '../config/environment'
+
 require 'rails/test_help'
 
 require 'minitest/pride'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,11 +2,10 @@ ENV["RAILS_ENV"] ||= "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'minitest/spec'
-require 'minitest/reporters'
+require 'minitest/pride'
 require 'minitest/rails/capybara'
 include Warden::Test::Helpers
 
-Minitest::Reporters.use!
 Capybara.javascript_driver = :webkit
 Warden.test_mode!
 DatabaseCleaner.strategy = :transaction


### PR DESCRIPTION
This should fix the "zeros" found in top users rankings in production's home page.

There was two problems with the old code:

- In last week's rankings, only users registered in the last week would be accounted. That's why we would get so many zeros. Instead, we want to consider all users but sort by "most ads published in the last week".

- The code was using a column `ads_count` which is not updated anywhere. I guess this was supposed to be a `counter_cache` column but it's not the case. My fix is to properly sort inline instead of relying on a `counter_cache` column, which is a hard to maintain because it needs create/save/delete callbacks. I don't think our current volume requires a `counter_cache` column.

I include some other changes that I made while debugging my test setup. Not really needed but they don't hurt, I think.

Note that I have only tried this through tests, it'd be good to try it in staging against real data.