### PR TITLE
Improvements in capistrano's config

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -3,7 +3,7 @@ server 'nolotiro.org', user: 'ruby-data', roles: %w{db web app}
 set :stage, :production
 set :rails_env, 'production' 
 set :deploy_to, '/var/www/nolotiro.org'
-set :branch, "production"
+set :branch, "master"
 
 set :rbenv_type, :user
 set :rbenv_ruby, '2.3.0'

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -3,7 +3,7 @@ server 'beta.nolotiro.org', user: 'ruby-data', roles: %w{db web app}
 set :stage, :staging
 set :rails_env, 'staging' 
 set :deploy_to, '/var/www/beta.nolotiro.org'
-set :branch, "staging"
+set :branch, ENV['BRANCH'] || "master"
 
 set :rbenv_type, :user
 set :rbenv_ruby, '2.3.0'


### PR DESCRIPTION
Estos son los cambios en el deploy que comentaba. La idea es desplegar siempre la rama master, que consideramos _siempre_ desplegable. Si una PR requiere pruebas con datos de producción se puede fácilmente desplegar en staging antes de dar el :+1: para mergear la rama en master, mediante:

```shell
BRANCH=mi_feature bundle exec cap staging deploy
```
De este modo aseguramos que master es siempre estable y desplegable, pero a la vez podemos probar fácilmente ramas WIP en staging.

¿Qué os parece? ¿Tiene sentido?

*NOTA*. No está probado ya que no tengo permisos de despliegue...
