### PR TITLE
More appearance stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 2.3.0
 before_install:
   - gem update --system
+  - gem install bundler
   - sudo apt-get update
   - sudo apt-get install -y sphinxsearch
   - cd vendor/geolite/ && wget --quiet --output-document gelolite.download.log http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz -O GeoLiteCity.dat.gz && gunzip GeoLiteCity.dat.gz && cd -

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 ruby '2.3.0'
 
-gem 'bundler', '>= 1.8.4'
 gem 'rails', '~> 4.2'
 gem 'haml-rails'
 gem 'sass-rails', '~> 4.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -468,7 +468,6 @@ DEPENDENCIES
   airbrake (~> 4.0)
   blueprint-rails
   bullet
-  bundler (>= 1.8.4)
   byebug
   cancancan (~> 1.10)
   capistrano (~> 3.0)

--- a/app/assets/stylesheets/common.css.sass.erb
+++ b/app/assets/stylesheets/common.css.sass.erb
@@ -255,7 +255,6 @@ form.searchbox
   float: right
   padding-left: 4px
   width: 100px
-  padding-top: 10px
 
 .no_results
   display: block

--- a/app/assets/stylesheets/common.css.sass.erb
+++ b/app/assets/stylesheets/common.css.sass.erb
@@ -224,8 +224,13 @@ form.searchbox
   overflow: hidden
 
   li
-    padding-right: 36px
     float: left
+
+    &:first-child
+      padding-right: 36px
+
+    &:last-child
+      padding-right: 0
 
 .ad_status
   display: inline-block

--- a/app/assets/stylesheets/common.css.sass.erb
+++ b/app/assets/stylesheets/common.css.sass.erb
@@ -256,6 +256,9 @@ form.searchbox
   padding-left: 4px
   width: 100px
 
+  a img
+    float: right
+
 .no_results
   display: block
   float: left

--- a/app/views/ads/_ad.html.erb
+++ b/app/views/ads/_ad.html.erb
@@ -1,5 +1,7 @@
 <% if ad.user %>
   <div class="ad_excerpt_home">
+    <%= render "ads/actions", ad: ad %>
+
     <% if ad.image.exists? %>
       <div class="ad_list_image">
         <%= link_to adslug_path(ad,ad.slug) do %>
@@ -7,8 +9,6 @@
         <% end %>
       </div>
     <% end %>
-
-    <%= render "ads/actions", ad: ad %>
 
     <h4>
       <%= link_to adslug_path(ad,ad.slug) do %>

--- a/app/views/ads/show.html.erb
+++ b/app/views/ads/show.html.erb
@@ -16,13 +16,13 @@
 <div id="main" class="row">
   <div class="span-12">
     <div class="ad_excerpt_show">
+      <%= render "ads/actions", ad: @ad %>
+
       <% if @ad.image.exists? %>
         <div class="ad_list_image">
           <%= link_to image_tag(@ad.image.url(:thumb), :alt => @ad.title), @ad.image.url, :rel => 'superbox[image]', :alt => t('nlt.click_to_large') %>
         </div>
       <% end %>
-
-      <%= render "ads/actions", ad: @ad %>
 
       <% if @ad.is_give? %>
         <span class="ad_status <%= @ad.status_class %>"><%= @ad.status_string %></span>


### PR DESCRIPTION
Pequeña mejora en la visualización de anuncios. La idea es que las acciones queden ubicadas encima del anuncio de manera visualmente consistente.

## Listados

Antes
![captura de pantalla de 2016-03-14 10 44 28](https://cloud.githubusercontent.com/assets/2887858/13740904/8581ed20-e9d3-11e5-9230-d3a8d1c99652.png)

Después
![captura de pantalla de 2016-03-14 10 45 03](https://cloud.githubusercontent.com/assets/2887858/13740898/7d90a76e-e9d3-11e5-9cba-827da5dd14b3.png)


## Página de anuncio

Antes
![captura de pantalla de 2016-03-14 10 38 39](https://cloud.githubusercontent.com/assets/2887858/13740924/9c64d0ac-e9d3-11e5-8842-7906f48027cf.png)

Después
![captura de pantalla de 2016-03-14 10 38 54](https://cloud.githubusercontent.com/assets/2887858/13740951/b8eb1f60-e9d3-11e5-8372-173616d5e1e3.png)
