### PR TITLE
Relax length limits

### DIFF
--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -31,7 +31,7 @@ class Ad < ActiveRecord::Base
   validates :woeid_code, presence: true
   validates :ip, presence: true
 
-  validates :title, length: {minimum: 10, maximum: 100}
+  validates :title, length: {minimum: 6, maximum: 100}
   validates :body, length: {minimum: 30, maximum: 1000}
 
   validates :status,

--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -32,7 +32,7 @@ class Ad < ActiveRecord::Base
   validates :ip, presence: true
 
   validates :title, length: {minimum: 10, maximum: 100}
-  validates :body, length: {minimum: 30, maximum: 500}
+  validates :body, length: {minimum: 30, maximum: 1000}
 
   validates :status,
     inclusion: { in: [1, 2, 3], message: "no es un estado válido" },

--- a/test/models/ad_test.rb
+++ b/test/models/ad_test.rb
@@ -48,10 +48,15 @@ class AdTest < ActiveSupport::TestCase
     assert @ad.errors[:status].include?("no es un estado válido")
   end
 
-  test "ad validates length of title" do
+  test "ad validates maximum length of title" do
     @ad.title = "a" * 200
     assert_not @ad.save
     assert @ad.errors[:title].include?("es demasiado largo (100 caracteres máximo)")
+  end
+
+  test "ad validates minimum length of title" do
+    assert_not @ad.update(title: "a" * 5)
+    assert @ad.errors[:title].include?("es demasiado corto (6 caracteres mínimo)")
   end
 
   test "ad escaped title and body with escape_privacy_data" do 

--- a/test/models/ad_test.rb
+++ b/test/models/ad_test.rb
@@ -48,7 +48,7 @@ class AdTest < ActiveSupport::TestCase
     assert @ad.errors[:status].include?("no es un estado válido")
   end
 
-  test "ad validates lenght" do
+  test "ad validates length of title" do
     @ad.title = "a" * 200
     assert_not @ad.save
     assert @ad.errors[:title].include?("es demasiado largo (100 caracteres máximo)")
@@ -61,6 +61,11 @@ class AdTest < ActiveSupport::TestCase
     @ad.update_attribute(:title, text)
     assert_equal(@ad.body, expected_text)
     assert_equal(@ad.title, expected_text)
+  end
+
+  test "ad validates length of body" do
+    assert_not @ad.update(body: "a" * 1001)
+    assert @ad.errors[:body].include?("es demasiado largo (1000 caracteres máximo)")
   end
 
   test "ad check slug" do


### PR DESCRIPTION
Tras publicar muchos anuncios recientemente, he encontrado ciertos límites demasiado restrictivos.

Es frustrante para un usuario tener que escribir "texto de relleno" o tener que resumir en exceso para poder publicar.