### PR TITLE
Bullet offenses

### DIFF
--- a/app/controllers/ads_controller.rb
+++ b/app/controllers/ads_controller.rb
@@ -102,7 +102,7 @@ class AdsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_ad
     #@ad = Rails.cache.fetch("set_ad_#{params[:id]}") do 
-    @ad = Ad.includes(:comments, :user).find(params[:id])
+    @ad = Ad.find(params[:id])
     #end
   end
 

--- a/app/controllers/ads_controller.rb
+++ b/app/controllers/ads_controller.rb
@@ -2,8 +2,7 @@ class AdsController < ApplicationController
   include ApplicationHelper
 
   before_action :set_ad, only: [:show, :edit, :update, :bump, :destroy]
-  #caches_action :list, :show, layout: false, unless: :current_user, skip_digest: true
-  #caches_action :index, :cache_path => Proc.new { |c| c.params }, unless: :current_user
+
   load_and_authorize_resource
 
   # GET /
@@ -101,9 +100,7 @@ class AdsController < ApplicationController
   private
   # Use callbacks to share common setup or constraints between actions.
   def set_ad
-    #@ad = Rails.cache.fetch("set_ad_#{params[:id]}") do 
     @ad = Ad.find(params[:id])
-    #end
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.


### PR DESCRIPTION
Nunca había usado la gema "bullet" y está guay.

Al cargar la página de un anuncio, me aparece una ventana emergente de bullet diciéndome que estamos haciendo un "eager loading" innecesario. Parece que tiene razón así que lo elimino.

También he aprovechado para eliminar unas líneas de código comentado.