### PR TITLE
[CSS] Actually break long words

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,8 @@ before_script:
   - mysql -e 'create database nolotirov3_test;'
   - cp config/secrets.yml.example config/secrets.yml
   - cp config/database.yml.travis config/database.yml
+branches:
+  only:
+    - master
 env:
   - DATABASE=mysql2 SPHINX_BIN=/usr/bin/ SPHINX_VERSION=2.0.4

--- a/app/assets/stylesheets/common.css.sass.erb
+++ b/app/assets/stylesheets/common.css.sass.erb
@@ -285,7 +285,13 @@ form.searchbox
   font-weight: bold
   margin-bottom: 3px
 
+=word-break
+  word-break: break-all
+  word-break: break-word
+
 .ad_excerpt
+  +word-break
+
   float: left
   border-bottom: 1px solid #DDD
   padding: 14px 18px 22px 18px
@@ -305,6 +311,8 @@ form.searchbox
   padding-bottom: 5px
 
 .ad_excerpt_show
+  +word-break
+
   display: block
   float: left
 
@@ -753,6 +761,8 @@ dl, dd
   margin-top: 8px
 
 #default_header_section
+  +word-break
+
   display: block
   background-color: #FFFFCC
   padding-top: 16px
@@ -760,7 +770,6 @@ dl, dd
   padding-left: 20px
   border: 1px solid #ddd
   margin-bottom: 20px
-  word-break: break-all
   h2
     font-size: 1em
     font-weight: bold


### PR DESCRIPTION
In 622ecac and 50fa084 we fixed an issue were words would be broken at
random places. But with that fix, we broke a previous fix for #100
(c9bf121 and bef91f8) because we don't break long words at all. This is
a compromise between the two: break just words when supported, fallback
to break anywhere otherwise (apparently this is just Safari and iOS).

Creo que esto sería suficiente para cerrar #100. Si notamos algún problema podemos reabrir.