### PR TITLE
si es usado por clases hijas, protected no private

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,8 +47,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  private
-
   def get_location_suggest 
     ip_address = GeoHelper.get_ip_address request
     GeoHelper.suggest ip_address


### PR DESCRIPTION
Si ese método es privado, no puede ser usado por clases hijas. Mejor protected.