### PR TITLE
Only givers in ranks

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,7 @@ class User < ActiveRecord::Base
   scope :top_overall, ->(limit = 20) do
     select("users.id, users.username, COUNT(ads.id) as n_ads")
       .joins(:ads)
+      .merge(Ad.give)
       .group("ads.user_owner")
       .order("n_ads DESC")
       .limit(limit)

--- a/app/views/ads/index.html.erb
+++ b/app/views/ads/index.html.erb
@@ -12,11 +12,11 @@
   </div>
 </div>
 
-<% cache("ads/location-ranks-#{Ad.cache_digest}") do %>
+<% cache("ads/#{I18n.locale}/location-ranks-#{Ad.cache_digest}") do %>
   <%= render :partial => "partials/section_locations" %>
 <% end %>
 
-<% cache("ads/user-ranks-#{Ad.cache_digest}") do %>
+<% cache("ads/#{I18n.locale}/user-ranks-#{Ad.cache_digest}") do %>
   <%= render :partial => "partials/section_users" %>
 <% end %>
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -90,14 +90,15 @@ class UserScopesTest < ActiveSupport::TestCase
     2.times { FactoryGirl.create(:ad, user: user2) }
   end
 
-  test "top overall ignores wanted ads" do
+  test "top overall ignores wanted ads from counts and results" do
     FactoryGirl.create(:ad, user: user3, type: 2)
+    user2.ads.last.update(type: 2)
 
     results = User.top_overall
 
     assert_equal(2, results.length)
     assert_count(results.first, user1.id, user1.username, 3)
-    assert_count(results.second, user2.id, user2.username, 2)
+    assert_count(results.second, user2.id, user2.username, 1)
   end
 
   test "top overall gives all time top ad publishers" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -96,7 +96,6 @@ class UserScopesTest < ActiveSupport::TestCase
     results = User.top_overall
 
     assert_equal(3, results.length)
-
     assert_count(results.first, user1.id, user1.username, 3)
     assert_count(results.second, user2.id, user2.username, 2)
     assert_count(results.third, user3.id, user3.username, 1)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -90,6 +90,16 @@ class UserScopesTest < ActiveSupport::TestCase
     2.times { FactoryGirl.create(:ad, user: user2) }
   end
 
+  test "top overall ignores wanted ads" do
+    FactoryGirl.create(:ad, user: user3, type: 2)
+
+    results = User.top_overall
+
+    assert_equal(2, results.length)
+    assert_count(results.first, user1.id, user1.username, 3)
+    assert_count(results.second, user2.id, user2.username, 2)
+  end
+
   test "top overall gives all time top ad publishers" do
     FactoryGirl.create(:ad, user: user3)
 


### PR DESCRIPTION
Esto resuelve

- El tema de no tener en cuenta anuncios de busco en los rankings.
- El tema de la generación de links en los rankings al cambiar de locale.

Como ambos temas afectaban a los rankings, los he incluído en la misma PR.