### PR TITLE
Add status filters to user ad list

### DIFF
--- a/app/assets/stylesheets/common.css.sass.erb
+++ b/app/assets/stylesheets/common.css.sass.erb
@@ -269,7 +269,6 @@ form.searchbox
 
 .filter_status
   z-index: 20
-  float: left
   padding: 10px 18px 12px 0
   width: 100% !important
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,6 +47,14 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def status_scope
+    return 'available' unless %w(booked delivered).include?(params[:status])
+
+    params[:status]
+  end
+
+  helper_method :status_scope
+
   private
 
   def get_location_suggest 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,10 @@ class UsersController < ApplicationController
   def listads
     # ads lists for user
     @user = User.find(params[:id])
-    @ads = @user.ads.includes(:user).paginate(:page => params[:page])
+    @ads = @user.ads
+                .includes(:user)
+                .public_send(status_scope)
+                .paginate(:page => params[:page])
   end
 
   # GET '/profile/:username'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,7 @@ class User < ActiveRecord::Base
       .joins(:ads)
       .merge(Ad.give)
       .group("ads.user_owner")
+      .unscope(:order)
       .order("n_ads DESC")
       .limit(limit)
   end

--- a/app/views/users/_tabnav.html.erb
+++ b/app/views/users/_tabnav.html.erb
@@ -7,11 +7,9 @@
     </li>
   <% end %>
   <li>
-  <% if request.fullpath =~ /\/profile\// %>
-    <%= t('nlt.profile') %>
-  <% else %>
-    <%= link_to t('nlt.profile'), profile_path(user) %>
-  <% end %>
+    <%= link_to_unless request.fullpath =~ /\/profile\//,
+                       t('nlt.profile'),
+                       profile_path(user) %>
   </li>
   <li>
   <%= link_to_unless_current t('nlt.user_ads'), listads_user_path(user) %>

--- a/app/views/users/listads.html.erb
+++ b/app/views/users/listads.html.erb
@@ -10,6 +10,8 @@
 
     <%= render partial: "users/tabnav", locals: {user: @user} %>
 
+    <%= render "woeid/filter_status" %>
+
     <div class="span-5 mobile">
       <div class="google_ad_wrapper">
         <%= render partial: "partials/google_adsense", locals: { class_name: "mobile google_adsense_336_280", ad_slot: "7225596067"}  %>
@@ -22,7 +24,7 @@
       <% end %>
       <%= render partial: "partials/pagination", locals: { items: @ads } %>
     <% else %>
-      <p> <div class="info"> <%= t("nlt.no_results.on_user") %> </div> </p>
+      <div class="info"> <%= t("nlt.no_results.on_user") %> </div>
     <% end %>
 
   </div>

--- a/app/views/woeid/_filter_status.html.erb
+++ b/app/views/woeid/_filter_status.html.erb
@@ -1,19 +1,8 @@
-<div class="filter_status">        
-  <% if all %>
-    <%= link_to t('nlt.all'), ads_listall_path(type: 'give'),
-      :class => status == "all" ? "actual" : "''" %>
-    <%= link_to t('nlt.available'), ads_listall_status_path(type: 'give', status: 'available'),
-      :class => status == "available" ? "actual" : "''" %>
-    <%= link_to t('nlt.booked'), ads_listall_status_path(type: 'give', status: 'booked'),
-      :class => status == "booked" ? "actual" : "''" %>
-    <%= link_to t('nlt.delivered'), ads_listall_status_path(type: 'give', status: 'delivered'),
-      :class => status == "delivered" ? "actual" : "''" %>
-  <% else %>
-    <%= link_to t('nlt.available'), ads_woeid_path(id: id, type: 'give'),
-      :class => status == "available" ? "actual" : "''" %>
-    <%= link_to t('nlt.booked'), ads_woeid_status_path(id: id, type: 'give', status: 'booked'), 
-      :class => status == "booked" ? "actual" : "''" %>
-    <%= link_to t('nlt.delivered'), ads_woeid_status_path(id: id, type: 'give', status: 'delivered'),
-      :class => status == "delivered" ? "actual" : "''" %>
-  <% end %>
+<div class="filter_status">
+  <%= link_to t('nlt.available'), url_for(type: 'give', status: 'available'),
+    :class => status_scope == "available" ? "actual" : "''" %>
+  <%= link_to t('nlt.booked'), url_for(type: 'give', status: 'booked'),
+    :class => status_scope == "booked" ? "actual" : "''" %>
+  <%= link_to t('nlt.delivered'), url_for(type: 'give', status: 'delivered'),
+    :class => status_scope == "delivered" ? "actual" : "''" %>
 </div>

--- a/app/views/woeid/show.html.erb
+++ b/app/views/woeid/show.html.erb
@@ -49,14 +49,9 @@
     </span>
     <div class="location_name">
       <h1>
-        <% if @search %>
-          <%= t('nlt.searching_on_html', q: @q) %>
-        <% end %>
-        <% if @type == "give" %>
-          <%= t('nlt.give') %>
-        <% else %>
-          <%= t('nlt.want') %>
-        <% end %>
+        <%= t('nlt.searching_on_html', q: @q) if @search %>
+
+        <%= @type == "give" ? t('nlt.give') : t('nlt.want') %>
         - <%= @woeid[:full] %>
       </h1>
       <br>

--- a/app/views/woeid/show.html.erb
+++ b/app/views/woeid/show.html.erb
@@ -1,4 +1,4 @@
-<% if @all %>
+<% if @woeid.nil? %>
   <% content_for(:title, t('nlt.all_ads')) %>
   <% content_for(:meta_title, t('nlt.all_ads')) %>
 <% else %>
@@ -10,7 +10,7 @@
   <meta name="description" content="<%= t('nlt.gift_on', woeid: @woeid) %>. <%= t('nlt.meta_description') %>" />
 <% end %>
 
-<% unless @search or @all %>
+<% unless @search or @woeid.nil? %>
   <% content_for :meta_extra do %>
     <link rel="alternate" type="application/rss+xml" title="nolotiro.org - <%= @woeid[:full] %>" href="<%= rss_type_url(woeid: @id, type: @type, status: @status) %>" />
   <% end %>
@@ -30,50 +30,46 @@
 <% end %>
 
 <div id="location_header_section">
-  <% if @all %>
-    <span class="give-want">
-      <%= link_to t('nlt.give'), ads_listall_path(type: 'give'),
-        :class => @type == "give" ? "actual" : "''" %>
-      &nbsp;
-      <%= link_to t('nlt.want'), ads_listall_path(type: 'want'), :class => @type == "want" ? "actual" : "''" %>
-    </span>
+  <span class="give-want">
+    <%= link_to t('nlt.give'), url_for(type: 'give'), :class => @type == "give" ? "actual" : "''" %>
+    &nbsp;
+    <%= link_to t('nlt.want'), url_for(type: 'want'), :class => @type == "want" ? "actual" : "''" %>
+  </span>
+
   <div class="location_name">
-    <h1><%= t('nlt.all_ads') %></h1>
-    <br>
-  </div>
-  <% else %>
-    <span class="give-want">
-      <%= link_to t('nlt.give'), ads_woeid_path(id: @id, type: 'give'), :class => @type == "give" ? "actual" : "''" %>
-      &nbsp;
-      <%= link_to t('nlt.want'), ads_woeid_path(id: @id, type: 'want'), :class => @type == "want" ? "actual" : "''" %>
-    </span>
-    <div class="location_name">
-      <h1>
+    <h1>
+      <% if @woeid.nil? %>
+        <%= t('nlt.all_ads') %>
+      <% else %>
         <%= t('nlt.searching_on_html', q: @q) if @search %>
 
         <%= @type == "give" ? t('nlt.give') : t('nlt.want') %>
         - <%= @woeid[:full] %>
-      </h1>
+      <% end %>
+    </h1>
+
+    <% if @woeid %>
       <br>
       <%= render :partial => "ads/search", :locals => {:woeid => @id, :ad_type => @type, :q => @q} %>
       <%= link_to location_ask_path, :class => "world_link" do %>
         <%= image_tag "change_location.png", :alt => "change location" %>
         <%= t('nlt.change_city') %>
       <% end %>
+    <% end %>
+  </div>
+</div>
+
+<div id="main">
+  <div class="span-17 mobile">
+    <div class="google_ad_wrapper">
+      <%= render partial: "partials/google_adsense", locals: { class_name: "google_adsense_336_280", ad_slot: "7225596067"}  %>
     </div>
-  <% end %>
   </div>
 
-  <div id="main">
-    <div class="span-17 mobile">
-      <div class="google_ad_wrapper">
-        <%= render partial: "partials/google_adsense", locals: { class_name: "google_adsense_336_280", ad_slot: "7225596067"}  %>
-      </div>
-    </div>
-    <div class="span-17">
-      <% if @type == "give" %>
-        <%= render :partial => "woeid/filter_status", :locals => {:status => @status, :id => @id, :all => @all} %>
-      <% end %>
+  <div class="span-17">
+    <% if @type == "give" %>
+      <%= render "woeid/filter_status" %>
+    <% end %>
 
     <% if @ads.any? %>
       <% @ads.each_with_index do |ad,i| %>
@@ -87,23 +83,26 @@
         <%= render :partial => "ads/no_results", :locals => { :location_suggest => @location_suggest, :location_options => @location_options, :woeid => @id } %>
       <% end %>
     <% end %>
-      <% if @woeid %>
-        <div class="rss">
-          <%= link_to rss_type_path(:woeid => @id, :type => "give") do %>
-            <%= image_tag "icons/rss.png", :alt => t("nlt.rss_suscribe") %>
-            &nbsp; <%= t('nlt.rss_suscribe') %> - <%= @woeid[:full] %>
-          <% end %>
-        </div>
-      <% end %>
-    </div><!-- /span-17 -->
-    <div class="span-6 desktop">
-      <div class="google_ad_wrapper">
-        <%= render partial: "partials/google_adsense", locals: { class_name: "google_adsense_600_160", ad_slot: "6783776462"}  %>
+
+    <% if @woeid %>
+      <div class="rss">
+        <%= link_to rss_type_path(:woeid => @id, :type => "give") do %>
+          <%= image_tag "icons/rss.png", :alt => t("nlt.rss_suscribe") %>
+          &nbsp; <%= t('nlt.rss_suscribe') %> - <%= @woeid[:full] %>
+        <% end %>
       </div>
-    </div><!-- /span-6 -->
-    <div class="span-17 mobile">
-      <div class="google_ad_wrapper">
-        <%= render partial: "partials/google_adsense", locals: { class_name: "google_adsense_336_280", ad_slot: "7225596067"}  %>
-      </div>
+    <% end %>
+  </div><!-- /span-17 -->
+
+  <div class="span-6 desktop">
+    <div class="google_ad_wrapper">
+      <%= render partial: "partials/google_adsense", locals: { class_name: "google_adsense_600_160", ad_slot: "6783776462"}  %>
+    </div>
+  </div><!-- /span-6 -->
+
+  <div class="span-17 mobile">
+    <div class="google_ad_wrapper">
+      <%= render partial: "partials/google_adsense", locals: { class_name: "google_adsense_336_280", ad_slot: "7225596067"}  %>
     </div>
   </div>
+</div>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -480,7 +480,7 @@ es:
     new_user: nuevo usuario
     no_results:
       explain_html: "<p>1. Sé el primero en %{publish}.</p> <p>2. Prueba a cambiar la ciudad por una mas grande que esté cerca de tu ubicación.</p> <p>3. Nuestro sistema de sugerencia de ubicación (basado en tu IP) dice que estas cerca de: <br> %{change_location} </p>"
-      on_user: No hay anuncios publicados por este usuario. 
+      on_user: No hay anuncios de este tipo publicados por este usuario.
       phrase: '"Un viaje de mil kilómetros comienza con un simple paso" Lao Tse.'
       publish_ad: publicar un anuncio en esta ciudad
       subtitle: Puedes probar alguna de estas cosas

--- a/test/controllers/woeid_controller_test.rb
+++ b/test/controllers/woeid_controller_test.rb
@@ -8,12 +8,6 @@ class WoeidControllerTest < ActionController::TestCase
     @ad = FactoryGirl.create(:ad)
   end
 
-  test "should get listall - want" do 
-    assert_generates '/ad/listall/ad_type/want', {controller: 'woeid', action: 'show', type: 'want' }
-    get :show, {type: 'want'}
-    assert_response :success
-  end
-
   test "should get listall and give (available, delivered, booked)" do 
     get :show, type: "give", status: "available"
     assert_response :success

--- a/test/integration/authenticated_ad_listing_test.rb
+++ b/test/integration/authenticated_ad_listing_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+require 'integration/concerns/authentication'
+require 'integration/concerns/pagination'
+
+class AuthenticatedAdListing < ActionDispatch::IntegrationTest
+  include Authentication
+  include Pagination
+
+  before do
+    create(:ad, title: 'ava_mad_1', woeid_code: 766_273, status: 1)
+    create(:ad, title: 'ava_bar', woeid_code: 753_692, status: 1)
+    create(:ad, title: 'ava_mad_2', woeid_code: 766_273, status: 1)
+    create(:ad, title: 'res_mad', woeid_code: 766_273, status: 2)
+    create(:ad, title: 'del_mad', woeid_code: 766_273, status: 3)
+
+    @user = create(:user, woeid: 766_273)
+    with_pagination(1) { login(@user.email, @user.password) }
+  end
+
+  it 'lists first page of available ads in users location in home page' do
+    page.assert_selector '.ad_excerpt_home', count: 1, text: 'ava_mad_1'
+  end
+
+  it 'lists other pages of available ads in users location in home page' do
+    with_pagination(1) { click_link 'siguiente' }
+
+    page.assert_selector '.ad_excerpt_home', count: 1, text: 'ava_mad_2'
+  end
+
+  it 'lists reserved ads in users location in home page' do
+    click_link 'reservado'
+
+    page.assert_selector '.ad_excerpt_home', count: 1, text: 'res_mad'
+  end
+
+  it 'lists delivered ads in users location in home page' do
+    click_link 'entregado'
+
+    page.assert_selector '.ad_excerpt_home', count: 1, text: 'del_mad'
+  end
+end

--- a/test/integration/concerns/authentication.rb
+++ b/test/integration/concerns/authentication.rb
@@ -1,0 +1,10 @@
+module Authentication
+  include Warden::Test::Helpers
+
+  def login(username, password)
+    visit new_user_session_path
+    fill_in "user_email", with: username
+    fill_in "user_password", with: password
+    click_button "Acceder"
+  end
+end

--- a/test/integration/concerns/pagination.rb
+++ b/test/integration/concerns/pagination.rb
@@ -1,0 +1,10 @@
+module Pagination
+  def with_pagination(n)
+    old_per_page = Ad.per_page
+    Ad.per_page = n
+
+    yield
+  ensure
+    Ad.per_page = old_per_page
+  end
+end

--- a/test/integration/personal_ad_listing_test.rb
+++ b/test/integration/personal_ad_listing_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+require 'integration/concerns/authentication'
+require 'integration/concerns/pagination'
+
+class PersonalAdListing < ActionDispatch::IntegrationTest
+  include Authentication
+  include Pagination
+
+  before do
+    @user = create(:user)
+
+    create(:ad, user: @user, title: 'ava_user_1', status: 1)
+    create(:ad, user: @user, title: 'ava_user_2', status: 1)
+    create(:ad, user: @user, title: 'res_user', status: 2)
+    create(:ad, user: @user, title: 'del_user', status: 3)
+    create(:ad, title: "something else to ensure it's filtered out")
+
+    with_pagination(1) do
+      login(@user.email, @user.password)
+      within('.user_login_box') { click_link @user.username }
+      click_link 'anuncios'
+    end
+  end
+
+  it 'lists first page of user available ads in user profile' do
+    page.assert_selector '.ad_excerpt_home', count: 1, text: 'ava_user_1'
+  end
+
+  it 'lists other pages of user ads in user profile' do
+    with_pagination(1) { click_link 'siguiente' }
+
+    page.assert_selector '.ad_excerpt_home', count: 1, text: 'ava_user_2'
+  end
+
+  it 'lists user reserved ads in users profile' do
+    click_link 'reservado'
+
+    page.assert_selector '.ad_excerpt_home', count: 1, text: 'res_user'
+  end
+
+  it 'lists user delivered ads in users profile' do
+    click_link 'entregado'
+
+    page.assert_selector '.ad_excerpt_home', count: 1, text: 'del_user'
+  end
+end

--- a/test/integration/unauthenticated_ad_listing_test.rb
+++ b/test/integration/unauthenticated_ad_listing_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+require 'integration/concerns/pagination'
+
+class UnauthenticatedAdListing < ActionDispatch::IntegrationTest
+  include Pagination
+
+  before do
+    create(:ad, title: 'ava_mad',
+                published_at: 1.hour.ago,
+                woeid_code: 766_273,
+                status: 1)
+
+    create(:ad, title: 'ava_bar',
+                published_at: 2.hour.ago,
+                woeid_code: 753_692,
+                status: 1)
+
+    create(:ad, title: 'res_mad', woeid_code: 766_273, status: 2)
+    create(:ad, title: 'del_ten', woeid_code: 773_692, status: 3)
+
+    with_pagination(1) { visit root_path }
+  end
+
+  it 'lists first page of available ads everywhere in home page' do
+    page.assert_selector '.ad_excerpt_home', count: 1, text: 'ava_mad'
+  end
+
+  it 'lists second page of available ads everywhere in all ads page' do
+    with_pagination(1) { click_link 'ver más anuncios' }
+
+    page.assert_selector '.ad_excerpt_home', count: 1, text: 'ava_bar'
+  end
+
+  it 'lists booked ads everywhere in all ads page' do
+    click_link 'ver más anuncios'
+    click_link 'reservado'
+
+    page.assert_selector '.ad_excerpt_home', count: 1, text: 'res_mad'
+  end
+
+  it 'lists booked ads everywhere in all ads page' do
+    click_link 'ver más anuncios'
+    click_link 'entregado'
+
+    page.assert_selector '.ad_excerpt_home', count: 1, text: 'del_ten'
+  end
+end

--- a/test/integration/user_lockable_test.rb
+++ b/test/integration/user_lockable_test.rb
@@ -1,9 +1,10 @@
 require "test_helper"
-include Warden::Test::Helpers
+require "integration/concerns/authentication"
 
 class UserLockable < ActionDispatch::IntegrationTest
-  it "should lock after 10 tries on user" do
+  include Authentication
 
+  it "should lock after 10 tries on user" do
     @user = FactoryGirl.create(:user)
 
     (1..8).each do |n|
@@ -17,15 +18,4 @@ class UserLockable < ActionDispatch::IntegrationTest
     login(@user.email, "trololololo")
     page.must_have_content I18n.t('devise.failure.locked')
   end
-
-  private
-
-  def login(username, password)
-    visit new_user_session_path
-    fill_in "user_email", with: @user.email
-    fill_in "user_password", with: "trololololo" 
-    click_button "Acceder"
-
-  end
-
 end


### PR DESCRIPTION
Esto soluciona #161 

Hasta ahora es la refactorización de código más grande que he hecho en nolotiro, con el riesgo de romper cosas que eso conlleva. Para prevenir eso, he escrito tests de integración para toda la funcionalidad envuelta en los cambios.

En cuanto a la feature en sí, añade filtros por tipo de anuncio en el perfil del usuario. Esto es muy útil cuando el usuario tiene varios anuncios activos para ver lo que a uno le queda por regalar, lo que tiene reservado, etc.

Antes
![captura de pantalla de 2016-03-26 11 17 40](https://cloud.githubusercontent.com/assets/2887858/14059548/f18cc916-f344-11e5-87dd-17d5263d6b06.png)


Después
![captura de pantalla de 2016-03-26 11 18 03](https://cloud.githubusercontent.com/assets/2887858/14059556/140ebfd0-f345-11e5-8f27-58f6268b2735.png)



El único cambio, a partir de la feature, es que se elimina el link de "Todos" en la página de "Todos los anuncios". Ese link no funcionaba en cualquier caso.

Antes
![captura de pantalla de 2016-03-26 11 20 32](https://cloud.githubusercontent.com/assets/2887858/14059553/04d860a2-f345-11e5-884f-6f11b65ed230.png)

Despues
![captura de pantalla de 2016-03-26 11 20 43](https://cloud.githubusercontent.com/assets/2887858/14059554/0cadd442-f345-11e5-8e3d-428b7a72558e.png)

¿Le echáis un ojo a ver qué os parece?