### PR TITLE
Add missing i18n keys

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,10 @@ module NolotiroOrg
     config.active_record.raise_in_transactional_callbacks = true
 
     config.active_job.queue_adapter = :sidekiq
-    
+
+    # Enable locale fallbacks
+    config.i18n.fallbacks = true
+
     # No usar TLS para conectar al SMTP ya 
     # que no tenemos un certificado válido
     config.action_mailer.smtp_settings = {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,10 +65,6 @@ NolotiroOrg::Application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation can not be found).
-  config.i18n.fallbacks = true
-
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -65,10 +65,6 @@ NolotiroOrg::Application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation can not be found).
-  config.i18n.fallbacks = true
-
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,4 +1,7 @@
+---
 ca:
+  active_admin:
+    dashboard: 
   activemodel:
     attributes:
       contact:
@@ -30,8 +33,8 @@ ca:
 
             No es pot eliminar el registre perquè existeixen dependents
         taken: no està disponible
-        too_long: "és massa llarg (%{count} caràcters màxim)"
-        too_short: "és massa curt (%{count} caràcters mínim)"
+        too_long: és massa llarg (%{count} caràcters màxim)
+        too_short: és massa curt (%{count} caràcters mínim)
         wrong_length: no té la longitud correcta (%{count} caràcters exactament)
       template:
         body: 'Hi ha hagut problemes amb els següents camps:'
@@ -48,6 +51,9 @@ ca:
         subject: Títol
         title: Títol
         type: Tipus
+      contact:
+        email: 
+        message: 
       message:
         subject: Assumpte
       user:
@@ -81,8 +87,8 @@ ca:
         record_invalid: 'La validació ha fallat: %{errors}'
         restrict_dependent_destroy: No es pot eliminar el registre perquè hi ha un(a) %{record} dependent
         taken: no està disponible
-        too_long: "és massa llarg (%{count} caràcters màxim)"
-        too_short: "és massa curt (%{count} caràcters mínim)"
+        too_long: és massa llarg (%{count} caràcters màxim)
+        too_short: és massa curt (%{count} caràcters mínim)
         wrong_length: no té la longitud correcta (%{count} caràcters exactament)
       template:
         body: 'Hi ha hagut problemes amb els següents camps:'
@@ -209,12 +215,19 @@ ca:
       reset_password_instructions:
         subject: "[nolotiro.org] Instruccions de regeneració de contrasenya"
       unlock_instructions:
+        action: 
+        greeting: 
+        instruction: 
+        message: 
         subject: "[nolotiro.org] Instruccions de desbloqueig"
     omniauth_callbacks:
       failure: No hem pogut autoritzar el compte des de %{kind} perquè "%{reason}".
       success: Autoritzat satisfactoriament el compte des de %{kind}.
     passwords:
       action: Canviar contrassenya
+      edit:
+        confirm_new_password: 
+        new_password: 
       follow_instructions: Algú ha demanat canviar la teva contrasenya de nolotiro.org. Si no has estat pots ignorar aquest correu. La teva contrasenya no canviarà fins que accedeixis a l'enllaç i creïs una nova.
       forgot: Has oblidat la teva contrasenya?
       instructions: Si us plau, introdueix el teu email i t'enviarem un enllaç d'accés directe per canviar la teva contrasenya.
@@ -238,6 +251,8 @@ ca:
       user:
         signed_in: Heu entrat.
     unlocks:
+      new:
+        resend_unlock_instructions: 
       send_instructions: En breu rebràs un correu electrònic amb instruccions sobre com desbloquejar el teu compte.
       send_paranoid_instructions: Si el teu compte existeix, rebràs un correu electrònic amb instruccions sobre com desbloquejar-lo.
       unlocked: El teu compte ha estat desbloquejat correctament. S'ha iniciat la sessió.
@@ -273,8 +288,8 @@ ca:
         one: No es pot eliminar el registre perquè hi ha un(a) %{record} dependent
         other: No es pot eliminar el registre perquè existeixen %{record} dependents
       taken: no està disponible
-      too_long: "és massa llarg (%{count} caràcters màxim)"
-      too_short: "és massa curt (%{count} caràcters mínim)"
+      too_long: és massa llarg (%{count} caràcters màxim)
+      too_short: és massa curt (%{count} caràcters mínim)
       wrong_length: no té la longitud correcta (%{count} caràcters exactament)
     template:
       body: 'Hi ha hagut problemes amb els següents camps:'
@@ -309,9 +324,11 @@ ca:
       you_have_new_message: Has rebut un nou missatge
       you_have_recieved_new_message: Has rebut un nou missatge
     new:
+      body_max: 
       button: Enviar
       errors: 'Hi ha un problema, revisa això:'
       legend: Enviar missatge
+      subject: 
       submit: Enviar
       title: Nou missatge privat per a l'usuari %{user}
     notification_mailer:
@@ -330,7 +347,7 @@ ca:
     table:
       date: Fecha
       delete: Esborrar?
-      last: "Últim"
+      last: Últim
       none: No tens missatges d'aquest tipus
       reciever: Rebut
       sender: Enviat
@@ -356,6 +373,7 @@ ca:
       lock_user: "[ADMIN] Bloquejar a aquest usuari"
       unlock_user: "[ADMIN] Desbloca a aquest usuari"
     ads:
+      bumped: 
       created: Hem creat l'anunci
       form:
         body: 'Cos de l''anunci:'
@@ -379,6 +397,7 @@ ca:
     back: tornar a la pàgina d'inici
     blog: bloc
     booked: reservat
+    bump_this_ad: 
     by_user: per l'usuari
     cancel_my_account: Cancel·lar el meu compte
     captcha_error: Possiblement has introduït malament els caràcters del captcha ja que no coindicen amb la imatge, torna a introduir-
@@ -397,6 +416,7 @@ ca:
     cities_in_the_world: ciutats del món que més reciclen
     click_to_large: Cliqueu per fer més gran foto
     comments:
+      body_max: 
       do_click: 'Fes clic en aquest enllaç per respondre el missatge:'
       flash_ko: Hi va haver un error en desar el teu comentari. Revisa-ho i enviar-lo de nou
       flash_ok: comentari guardat
@@ -431,7 +451,7 @@ ca:
       question_1: Quin és el propòsit d'aquest projecte?
       question_2: Llavors ... Aquest web no és per ajudar els altres?
       question_3: Però a mi m'agradaria regalar les meves coses a algú que realment ho necessiti
-      question_4: "És veritat que hi ha gent que després venen les coses que regalen aquí?"
+      question_4: És veritat que hi ha gent que després venen les coses que regalen aquí?
       question_5: Quina classe d'anuncis puc publicar a nolotiro?
       question_6: "¿No està permès l'intercanvi d'objectes? que estrany"
       question_7: Puc enviar coses a gent que no viu a la meva ciutat?
@@ -450,8 +470,12 @@ ca:
     if_you_are_new: Si ets un nou usuari, si us plau
     if_youre_already_an_user: Si ja ets un usuari registrat, si us plau
     keywords: regal segona mà gratis
-    last_published_gifts: "últims regals publicats"
+    last_published_gifts: últims regals publicats
     leave_blank: "(deixa-la en blanc si no vols canviar-la)"
+    legal_notice: 
+    legal_page:
+      body_html: 
+      title: 
     login: accedir
     login_to_comment: accedeix per escriure un comentari
     logout: sortir
@@ -469,6 +493,7 @@ ca:
     new_user: nou usuari
     no_results:
       explain_html: "<p> 1. Sigues el primer a %{publish}.</p> <p>2. Prova a canviar la ciutat per una més gran que estigui a prop de la teva ubicació. </p> <p> 3. El nostre sistema de suggeriment d'ubicació (basat en la teva IP) diu que aquestes prop de: <br> %{change_location} </p>"
+      on_user: 
       phrase: '"Un viatge de mil quilòmetres comença amb un simple pas" Lao Tse.'
       publish_ad: publicar un anunci en aquesta ciutat
       subtitle: Pots provar alguna d'aquestes coses
@@ -511,6 +536,7 @@ ca:
     send: Enviar
     send_a_message: "+ Envia un missatge privat a l'anunciant"
     send_a_message_to: envia un missatge privat a
+    send_a_private_message: 
     sending_this_form: Enviant aquest formulari, admeten haver llegit, comprès, i estàs d'acord amb les nostres
     share_this_ad: Comparteix aquest anunci
     sign_in: Accedir
@@ -537,6 +563,7 @@ ca:
     users_most_active_last_week: usuaris més actius en la darrera setmana
     view_ads_on: Veure anuncis en %{location_suggest}
     view_ads_on_your_city: Veure anuncis a la teva ciutat o poble
+    view_more_ads: 
     want: busco
     want_to_leave: Vols esborrar el teu usuari?
     we_need_your_password: "(necessitem la contrasenya per confirmar els canvis)"

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -534,7 +534,7 @@ ca:
     user_profile: Perfil d'usuari
     username: Nom d'usuari
     users_most_active: usuaris més actius
-    users_most_active_last_week: 
+    users_most_active_last_week: usuaris més actius en la darrera setmana
     view_ads_on: Veure anuncis en %{location_suggest}
     view_ads_on_your_city: Veure anuncis a la teva ciutat o poble
     want: busco

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,4 +1,7 @@
+---
 de:
+  active_admin:
+    dashboard: 
   activemodel:
     attributes:
       contact:
@@ -44,6 +47,9 @@ de:
         subject: 
         title: 
         type: 
+      contact:
+        email: 
+        message: 
       message:
         subject: 
       user:
@@ -205,12 +211,19 @@ de:
       reset_password_instructions:
         subject: Anleitung für das Zurücksetzen Ihres Passworts
       unlock_instructions:
+        action: 
+        greeting: 
+        instruction: 
+        message: 
         subject: Anleitung für die Account-Freischaltung
     omniauth_callbacks:
       failure: Sie konnten nicht mit Ihrem %{kind}-Account angemeldet werden, weil "%{reason}".
       success: Sie haben sich erfolgreich mit Ihrem %{kind}-Account angemeldet.
     passwords:
       action: 
+      edit:
+        confirm_new_password: 
+        new_password: 
       follow_instructions: 
       forgot: 
       instructions: 
@@ -234,6 +247,8 @@ de:
       user:
         signed_in: 
     unlocks:
+      new:
+        resend_unlock_instructions: 
       send_instructions: Sie erhalten in wenigen Minuten eine E-Mail mit der Anleitung, wie Sie Ihren Account entsperren können.
       send_paranoid_instructions: Falls Ihre E-Mail-Adresse in unserer Datenbank existiert, erhalten Sie in wenigen Minuten eine E-Mail mit der Anleitung, wie Sie Ihren Account entsperren können.
       unlocked: Ihr Account wurde entsperrt. Sie sind jetzt angemeldet.
@@ -265,7 +280,9 @@ de:
         other: 'Konnte %{resource} nicht speichern: %{count} Fehler.'
       odd: muss ungerade sein
       record_invalid: 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
-      restrict_dependent_destroy: 
+      restrict_dependent_destroy:
+        one: 
+        other: 
       taken: ist bereits vergeben
       too_long: ist zu lang (mehr als %{count} Zeichen)
       too_short: ist zu kurz (weniger als %{count} Zeichen)
@@ -303,9 +320,11 @@ de:
       you_have_new_message: 
       you_have_recieved_new_message: 
     new:
+      body_max: 
       button: 
       errors: 
       legend: 
+      subject: 
       submit: 
       title: 
     notification_mailer:
@@ -350,6 +369,7 @@ de:
       lock_user: 
       unlock_user: 
     ads:
+      bumped: 
       created: 
       form:
         body: 
@@ -373,6 +393,7 @@ de:
     back: 
     blog: 
     booked: 
+    bump_this_ad: 
     by_user: 
     cancel_my_account: 
     captcha_error: 
@@ -391,6 +412,7 @@ de:
     cities_in_the_world: 
     click_to_large: 
     comments:
+      body_max: 
       do_click: 
       flash_ko: 
       flash_ok: 
@@ -398,7 +420,9 @@ de:
       subject: 
       submit: 
       title: 
-    comments_count: 
+    comments_count:
+      one: 
+      other: 
     contact: 
     contact_form: 
     contact_legend: 
@@ -444,6 +468,10 @@ de:
     keywords: 
     last_published_gifts: 
     leave_blank: 
+    legal_notice: 
+    legal_page:
+      body_html: 
+      title: 
     login: 
     login_to_comment: 
     logout: 
@@ -461,6 +489,7 @@ de:
     new_user: 
     no_results:
       explain_html: 
+      on_user: 
       phrase: 
       publish_ad: 
       subtitle: 
@@ -503,6 +532,7 @@ de:
     send: 
     send_a_message: 
     send_a_message_to: 
+    send_a_private_message: 
     sending_this_form: 
     share_this_ad: 
     sign_in: 
@@ -529,6 +559,7 @@ de:
     users_most_active_last_week: 
     view_ads_on: 
     view_ads_on_your_city: 
+    view_more_ads: 
     want: 
     want_to_leave: 
     we_need_your_password: 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,7 @@
+---
 en:
+  active_admin:
+    dashboard: 
   activemodel:
     attributes:
       contact:
@@ -44,6 +47,9 @@ en:
         subject: Title
         title: Title
         type: Type
+      contact:
+        email: 
+        message: 
       message:
         subject: Subject
       user:
@@ -201,12 +207,19 @@ en:
       reset_password_instructions:
         subject: Reset password instructions
       unlock_instructions:
+        action: 
+        greeting: 
+        instruction: 
+        message: 
         subject: Unlock Instructions
     omniauth_callbacks:
       failure: Could not authenticate you from %{kind} because "%{reason}".
       success: Successfully authenticated from %{kind} account.
     passwords:
       action: Change Password
+      edit:
+        confirm_new_password: 
+        new_password: 
       follow_instructions: Someone asked nolotiro.org about change your password. If it's not you then you can ignore this mail. Your password will not change until you access the link and create a new one.
       forgot: Did you forget your password?
       instructions: Please, enter your email address and we will send you a shortcut link to change your password.
@@ -230,6 +243,8 @@ en:
       user:
         signed_in: You are signed.
     unlocks:
+      new:
+        resend_unlock_instructions: 
       send_instructions: You will receive an email with instructions about how to unlock your account in a few minutes.
       send_paranoid_instructions: If your account exists, you will receive an email with instructions about how to unlock it in a few minutes.
       unlocked: Your account has been unlocked successfully. Please sign in to continue.
@@ -301,9 +316,11 @@ en:
       you_have_new_message: You have a new message
       you_have_recieved_new_message: You have a new message
     new:
+      body_max: 
       button: Send
       errors: 'There is a problem, please check this:'
       legend: Send message
+      subject: 
       submit: Send
       title: New private message for user %{user}
     notification_mailer:
@@ -348,6 +365,7 @@ en:
       lock_user: "[ADMIN] Block this user"
       unlock_user: "[ADMIN] Unblock this user"
     ads:
+      bumped: 
       created: We have created the ad
       form:
         body: 'Body of the ad:'
@@ -371,6 +389,7 @@ en:
     back: Back to the main page
     blog: blog
     booked: reserved
+    bump_this_ad: 
     by_user: by user
     cancel_my_account: Cancel my account
     captcha_error: Does not match, please, enter captcha's characters again
@@ -389,6 +408,7 @@ en:
     cities_in_the_world: best recycling cities
     click_to_large: Click to large the photo
     comments:
+      body_max: 
       do_click: Please click this link to reply the message
       flash_ko: It is not possible to save your comment, there is an error, please review it and send your comment again
       flash_ok: Saved comment
@@ -448,6 +468,10 @@ en:
     keywords: gift second hand free
     last_published_gifts: last posted gifts
     leave_blank: "(leave it empty if you do not want to change it)"
+    legal_notice: 
+    legal_page:
+      body_html: 
+      title: 
     login: log in
     login_to_comment: log in to write a comment
     logout: logout
@@ -465,6 +489,7 @@ en:
     new_user: sign up
     no_results:
       explain_html: "<p>1. Be the first to %{publish}.</p> <p>2. Try a bigger city close to your location.</p> <p>3. Our city suggestion system IP based tell us you are close to: <br> %{change_location} </p>"
+      on_user: 
       phrase: '"The journey of a thousand miles begins with one step" Lao Tse.'
       publish_ad: post an ad in this city
       subtitle: You can try some of this stuff
@@ -507,6 +532,7 @@ en:
     send: Send
     send_a_message: "+ Send a private message to this user"
     send_a_message_to: send a private message to
+    send_a_private_message: 
     sending_this_form: By submitting this form, you admit to having read, understood, and you agree with our
     share_this_ad: Share this ad
     sign_in: Sign in
@@ -533,6 +559,7 @@ en:
     users_most_active_last_week: 
     view_ads_on: View ads in %{location_suggest}
     view_ads_on_your_city: View ads from your city or town
+    view_more_ads: 
     want: want
     want_to_leave: Do you want to delete your user?
     we_need_your_password: "(we need your password to confirm your edition)"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,4 +1,7 @@
+---
 es:
+  active_admin:
+    dashboard: 
   activemodel:
     attributes:
       contact:
@@ -212,12 +215,19 @@ es:
       reset_password_instructions:
         subject: "[nolotiro.org] Instrucciones de recuperación de contraseña"
       unlock_instructions:
+        action: 
+        greeting: 
+        instruction: 
+        message: 
         subject: "[nolotiro.org] Instrucciones para desbloquear"
     omniauth_callbacks:
       failure: No has sido autorizado en la cuenta %{kind} porque "%{reason}".
       success: Has sido autorizado satisfactoriamente de la cuenta %{kind}.
     passwords:
       action: Cambiar contraseña
+      edit:
+        confirm_new_password: 
+        new_password: 
       follow_instructions: Alguien ha pedido cambiar tu contraseña de nolotiro.org. Si no has sido puedes ignorar este correo. Tu contraseña no cambiará hasta que accedas al enlace y crees una nueva.
       forgot: "¿Has olvidado tu contraseña?"
       instructions: Por favor, introduce tu email y te enviaremos un enlace de acceso directo para cambiar tu contraseña.
@@ -241,6 +251,8 @@ es:
       user:
         signed_in: Has iniciado sesión.
     unlocks:
+      new:
+        resend_unlock_instructions: 
       send_instructions: Vas a recibir instrucciones para desbloquear tu cuenta en unos pocos minutos.
       send_paranoid_instructions: Si tu cuenta existe, vas a recibir instrucciones para desbloquear tu cuenta en unos pocos minutos.
       unlocked: Tu cuenta fue desbloqueada. Tu cuenta fue desbloqueada. Ya puedes iniciar sesión.
@@ -335,7 +347,7 @@ es:
     table:
       date: Fecha
       delete: "¿Borrar?"
-      last: "Último"
+      last: Último
       none: No tienes mensajes de este tipo
       reciever: Recibido
       sender: Enviado
@@ -361,6 +373,7 @@ es:
       lock_user: "[ADMIN] Bloquear a este usuario"
       unlock_user: "[ADMIN] Desbloquear a este usuario"
     ads:
+      bumped: Hemos republicado el anuncio
       created: Hemos creado el anuncio
       form:
         body: 'Cuerpo del anuncio:'
@@ -375,7 +388,6 @@ es:
         title_max: Máximo 100 caracteres
         to_publish: Para publicar tu anuncio, por favor, introduce estos datos
         type_ad: 'Tipo de anuncio:'
-      bumped: Hemos republicado el anuncio
       updated: Hemos actualizado el anuncio
     all: todos
     all_ads: todos los anuncios
@@ -385,6 +397,7 @@ es:
     back: volver a la página de inicio
     blog: blog
     booked: reservado
+    bump_this_ad: Republica este anuncio
     by_user: 'por '
     cancel_my_account: Cancelar mi cuenta
     captcha_error: Posiblemente has introducido mal los caracteres del captcha ya que no coindicen con la imagen, vuelve a introducirlos
@@ -428,7 +441,6 @@ es:
     didn_t_receive_confirmation_instructions: "¿No has recibido las instrucciones de confirmación?"
     didn_t_receive_unlock_instructions: "¿No has recibido las instrucciones para el desbloqueo?"
     edit_this_ad: Edita este anuncio
-    bump_this_ad: Republica este anuncio
     faq:
       answer_1_html: El propósito fundamental de esta web es el de deshacernos de los objetos que ya no utilizamos y nos estorban en casa.
       answer_2_html: 'Primero a ti directamente pudiéndote deshacer de esas cosas que ya no quieres, y siempre al que regalas algo implícitamente. Lo mejor es enfocarlo egoistamente y controlar la relación de causa-efecto que vamos a desencadenar regalando.<br> Si enfocamos dicho acto de regalar objetos desde una perspectiva  egoísta, la de deshacernos de cosas útiles, pero que nos molestan,porque nos estorban, porque van a ir a la basura, porque son objetos desahuciados ... siempre tendremos una buena experiencia, al no esperar nada mas que  librarnos de dichos objetos. <br> Y el saber que alguien le está dando uso o provecho reforzará esa experiencia como positiva. <br> Es decir: el acto de regalar cosas de valor o útiles siempre es algo positivo si no esperamos una recompensa moral o aplacar nuestra conciencia.'
@@ -459,13 +471,12 @@ es:
     if_you_are_new: Si eres un nuevo usuario, por favor
     if_youre_already_an_user: Si ya eres un usuario registrado, por favor
     keywords: 'regalo segunda mano gratis '
-    last_published_gifts: "últimos regalos publicados"
+    last_published_gifts: últimos regalos publicados
     leave_blank: "(déjala en blanco si no quieres cambiarla)"
     legal_notice: aviso legal
     legal_page:
-      title: Aviso legal
       body_html: 'Nombre: Asociación aLabs. <br>Inscrita en el registro de asociaciones de la Comunidad de Madrid con número 32.022. <br>CIF: G86139847<br> C/Duque de Alba, 13 (28012) Madrid.'
-
+      title: Aviso legal
     login: acceder
     login_to_comment: accede para escribir un comentario
     logout: salir
@@ -525,8 +536,8 @@ es:
     searching_on_html: Buscando <i>%{q}</i> en
     send: Enviar
     send_a_message: "+ Envía un mensaje privado al anunciante"
-    send_a_private_message: "+ Envía un mensaje privado al anunciante"
     send_a_message_to: 'envía un mensaje privado a '
+    send_a_private_message: "+ Envía un mensaje privado al anunciante"
     sending_this_form: Enviando este formulario, admites haber leido, comprendido, y estás conforme con nuestras
     share_this_ad: Comparte este anuncio
     sign_in: Acceder
@@ -553,7 +564,7 @@ es:
     users_most_active_last_week: usuarios más activos en la última semana
     view_ads_on: Ver anuncios en %{location_suggest}
     view_ads_on_your_city: Ver anuncios en tu ciudad o pueblo
-    view_more_ads: "ver más anuncios >"
+    view_more_ads: ver más anuncios >
     want: busco
     want_to_leave: "¿Quieres borrar tu usuario?"
     we_need_your_password: "(necesitamos tu contraseña para confirmar tus cambios)"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -52,6 +52,9 @@ es:
       message:
         subject: Subject
       user:
+        Contraseña: Contraseña
+        Recuérdame: Recuérdame
+        Tu email: Tu email
         current_password: Contraseña actual
         email: Correo electrónico
         password: Contraseña nueva

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -1,4 +1,7 @@
+---
 eu:
+  active_admin:
+    dashboard: 
   activemodel:
     attributes:
       contact:
@@ -44,6 +47,9 @@ eu:
         subject: 
         title: 
         type: 
+      contact:
+        email: 
+        message: 
       message:
         subject: 
       user:
@@ -205,12 +211,19 @@ eu:
       reset_password_instructions:
         subject: 
       unlock_instructions:
+        action: 
+        greeting: 
+        instruction: 
+        message: 
         subject: 
     omniauth_callbacks:
       failure: 
       success: 
     passwords:
       action: 
+      edit:
+        confirm_new_password: 
+        new_password: 
       follow_instructions: 
       forgot: 
       instructions: 
@@ -234,6 +247,8 @@ eu:
       user:
         signed_in: 
     unlocks:
+      new:
+        resend_unlock_instructions: 
       send_instructions: 
       send_paranoid_instructions: 
       unlocked: 
@@ -260,10 +275,14 @@ eu:
       not_an_integer: zenbaki osoa izan behar da
       not_found: 
       not_locked: 
-      not_saved: 
+      not_saved:
+        one: 
+        other: 
       odd: bakoitia izan behar du
       record_invalid: 'Balioztatze arazoa: %{errors}'
-      restrict_dependent_destroy: 
+      restrict_dependent_destroy:
+        one: 
+        other: 
       taken: hartuta dago
       too_long: luzeegia da (%{count} karaktere gehienez)
       too_short: laburregia da (%{count} karaktere gutxienez)
@@ -301,9 +320,11 @@ eu:
       you_have_new_message: 
       you_have_recieved_new_message: 
     new:
+      body_max: 
       button: 
       errors: 
       legend: 
+      subject: 
       submit: 
       title: 
     notification_mailer:
@@ -348,6 +369,7 @@ eu:
       lock_user: 
       unlock_user: 
     ads:
+      bumped: 
       created: 
       form:
         body: 
@@ -371,6 +393,7 @@ eu:
     back: 
     blog: 
     booked: 
+    bump_this_ad: 
     by_user: 
     cancel_my_account: 
     captcha_error: 
@@ -389,6 +412,7 @@ eu:
     cities_in_the_world: 
     click_to_large: 
     comments:
+      body_max: 
       do_click: 
       flash_ko: 
       flash_ok: 
@@ -396,7 +420,9 @@ eu:
       subject: 
       submit: 
       title: 
-    comments_count: 
+    comments_count:
+      one: 
+      other: 
     contact: 
     contact_form: 
     contact_legend: 
@@ -442,6 +468,10 @@ eu:
     keywords: 
     last_published_gifts: 
     leave_blank: 
+    legal_notice: 
+    legal_page:
+      body_html: 
+      title: 
     login: 
     login_to_comment: 
     logout: 
@@ -459,6 +489,7 @@ eu:
     new_user: 
     no_results:
       explain_html: 
+      on_user: 
       phrase: 
       publish_ad: 
       subtitle: 
@@ -501,6 +532,7 @@ eu:
     send: 
     send_a_message: 
     send_a_message_to: 
+    send_a_private_message: 
     sending_this_form: 
     share_this_ad: 
     sign_in: 
@@ -527,6 +559,7 @@ eu:
     users_most_active_last_week: 
     view_ads_on: 
     view_ads_on_your_city: 
+    view_more_ads: 
     want: 
     want_to_leave: 
     we_need_your_password: 
@@ -606,7 +639,11 @@ eu:
     page_entries_info:
       multi_page: 
       multi_page_html: 
-      single_page: 
-      single_page_html: 
+      single_page:
+        one: 
+        other: 
+      single_page_html:
+        one: 
+        other: 
     page_gap: 
     previous_label: 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,4 +1,7 @@
+---
 fr:
+  active_admin:
+    dashboard: 
   activemodel:
     attributes:
       contact:
@@ -52,6 +55,9 @@ fr:
         subject: 
         title: 
         type: 
+      contact:
+        email: 
+        message: 
       message:
         subject: 
       user:
@@ -223,12 +229,19 @@ fr:
       reset_password_instructions:
         subject: Instructions pour changer le mot de passe
       unlock_instructions:
+        action: 
+        greeting: 
+        instruction: 
+        message: 
         subject: Instructions pour déverrouiller le compte
     omniauth_callbacks:
       failure: 'Nous ne pouvons pas vous authentifier depuis %{kind} pour la raison suivante : ''%{reason}''.'
       success: Autorisé avec succès par votre compte %{kind}.
     passwords:
       action: 
+      edit:
+        confirm_new_password: 
+        new_password: 
       follow_instructions: 
       forgot: 
       instructions: 
@@ -252,6 +265,8 @@ fr:
       user:
         signed_in: 
     unlocks:
+      new:
+        resend_unlock_instructions: 
       send_instructions: Vous allez recevoir un email sous quelques minutes contenant les instructions nécessaires au déblocage de votre compte.
       send_paranoid_instructions: Si votre compte existe, vous recevrez un email indiquant comment le déverrouiller sous quelques minutes.
       unlocked: Votre compte a été débloqué avec succès. Veuillez vous connecter.
@@ -329,9 +344,11 @@ fr:
       you_have_new_message: 
       you_have_recieved_new_message: 
     new:
+      body_max: 
       button: 
       errors: 
       legend: 
+      subject: 
       submit: 
       title: 
     notification_mailer:
@@ -376,6 +393,7 @@ fr:
       lock_user: 
       unlock_user: 
     ads:
+      bumped: 
       created: 
       form:
         body: 
@@ -399,6 +417,7 @@ fr:
     back: 
     blog: 
     booked: 
+    bump_this_ad: 
     by_user: 
     cancel_my_account: 
     captcha_error: 
@@ -417,6 +436,7 @@ fr:
     cities_in_the_world: 
     click_to_large: 
     comments:
+      body_max: 
       do_click: 
       flash_ko: 
       flash_ok: 
@@ -424,7 +444,9 @@ fr:
       subject: 
       submit: 
       title: 
-    comments_count: 
+    comments_count:
+      one: 
+      other: 
     contact: 
     contact_form: 
     contact_legend: 
@@ -470,6 +492,10 @@ fr:
     keywords: 
     last_published_gifts: 
     leave_blank: 
+    legal_notice: 
+    legal_page:
+      body_html: 
+      title: 
     login: 
     login_to_comment: 
     logout: 
@@ -487,6 +513,7 @@ fr:
     new_user: 
     no_results:
       explain_html: 
+      on_user: 
       phrase: 
       publish_ad: 
       subtitle: 
@@ -529,6 +556,7 @@ fr:
     send: 
     send_a_message: 
     send_a_message_to: 
+    send_a_private_message: 
     sending_this_form: 
     share_this_ad: 
     sign_in: 
@@ -555,6 +583,7 @@ fr:
     users_most_active_last_week: 
     view_ads_on: 
     view_ads_on_your_city: 
+    view_more_ads: 
     want: 
     want_to_leave: 
     we_need_your_password: 

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -1,4 +1,7 @@
+---
 gl:
+  active_admin:
+    dashboard: 
   activemodel:
     attributes:
       contact:
@@ -26,8 +29,8 @@ gl:
         record_invalid: 
         restrict_dependent_destroy: 
         taken: non está dispoñible
-        too_long: "é demasiado longo (non máis de %{count} carácteres)"
-        too_short: "é demasiado curto (non menos de %{count} carácteres)"
+        too_long: é demasiado longo (non máis de %{count} carácteres)
+        too_short: é demasiado curto (non menos de %{count} carácteres)
         wrong_length: non ten a lonxitude correcta (debe ser de %{count} carácteres)
       template:
         body: 'Atopáronse os seguintes problemas:'
@@ -44,6 +47,9 @@ gl:
         subject: 
         title: 
         type: 
+      contact:
+        email: 
+        message: 
       message:
         subject: 
       user:
@@ -77,8 +83,8 @@ gl:
         record_invalid: 
         restrict_dependent_destroy: 
         taken: non está dispoñible
-        too_long: "é demasiado longo (non máis de %{count} carácteres)"
-        too_short: "é demasiado curto (non menos de %{count} carácteres)"
+        too_long: é demasiado longo (non máis de %{count} carácteres)
+        too_short: é demasiado curto (non menos de %{count} carácteres)
         wrong_length: non ten a lonxitude correcta (debe ser de %{count} carácteres)
       template:
         body: 'Atopáronse os seguintes problemas:'
@@ -149,7 +155,9 @@ gl:
       about_x_years:
         one: aproximadamente 1 ano
         other: "%{count} anos"
-      almost_x_years: 
+      almost_x_years:
+        one: 
+        other: 
       half_a_minute: medio minuto
       less_than_x_minutes:
         one: 1 minuto
@@ -206,12 +214,19 @@ gl:
       reset_password_instructions:
         subject: 
       unlock_instructions:
+        action: 
+        greeting: 
+        instruction: 
+        message: 
         subject: 
     omniauth_callbacks:
       failure: 
       success: 
     passwords:
       action: 
+      edit:
+        confirm_new_password: 
+        new_password: 
       follow_instructions: 
       forgot: 
       instructions: 
@@ -235,6 +250,8 @@ gl:
       user:
         signed_in: 
     unlocks:
+      new:
+        resend_unlock_instructions: 
       send_instructions: 
       send_paranoid_instructions: 
       unlocked: 
@@ -261,13 +278,17 @@ gl:
       not_an_integer: 
       not_found: 
       not_locked: 
-      not_saved: 
+      not_saved:
+        one: 
+        other: 
       odd: debe ser par
       record_invalid: 
-      restrict_dependent_destroy: 
+      restrict_dependent_destroy:
+        one: 
+        other: 
       taken: non está dispoñible
-      too_long: "é demasiado longo (non máis de %{count} carácteres)"
-      too_short: "é demasiado curto (non menos de %{count} carácteres)"
+      too_long: é demasiado longo (non máis de %{count} carácteres)
+      too_short: é demasiado curto (non menos de %{count} carácteres)
       wrong_length: non ten a lonxitude correcta (debe ser de %{count} carácteres)
     template:
       body: 'Atopáronse os seguintes problemas:'
@@ -302,9 +323,11 @@ gl:
       you_have_new_message: 
       you_have_recieved_new_message: 
     new:
+      body_max: 
       button: 
       errors: 
       legend: 
+      subject: 
       submit: 
       title: 
     notification_mailer:
@@ -349,6 +372,7 @@ gl:
       lock_user: 
       unlock_user: 
     ads:
+      bumped: 
       created: 
       form:
         body: 
@@ -372,6 +396,7 @@ gl:
     back: 
     blog: 
     booked: 
+    bump_this_ad: 
     by_user: 
     cancel_my_account: 
     captcha_error: 
@@ -390,6 +415,7 @@ gl:
     cities_in_the_world: 
     click_to_large: 
     comments:
+      body_max: 
       do_click: 
       flash_ko: 
       flash_ok: 
@@ -397,7 +423,9 @@ gl:
       subject: 
       submit: 
       title: 
-    comments_count: 
+    comments_count:
+      one: 
+      other: 
     contact: 
     contact_form: 
     contact_legend: 
@@ -443,6 +471,10 @@ gl:
     keywords: 
     last_published_gifts: 
     leave_blank: 
+    legal_notice: 
+    legal_page:
+      body_html: 
+      title: 
     login: 
     login_to_comment: 
     logout: 
@@ -460,6 +492,7 @@ gl:
     new_user: 
     no_results:
       explain_html: 
+      on_user: 
       phrase: 
       publish_ad: 
       subtitle: 
@@ -502,6 +535,7 @@ gl:
     send: 
     send_a_message: 
     send_a_message_to: 
+    send_a_private_message: 
     sending_this_form: 
     share_this_ad: 
     sign_in: 
@@ -528,6 +562,7 @@ gl:
     users_most_active_last_week: 
     view_ads_on: 
     view_ads_on_your_city: 
+    view_more_ads: 
     want: 
     want_to_leave: 
     we_need_your_password: 
@@ -607,7 +642,11 @@ gl:
     page_entries_info:
       multi_page: 
       multi_page_html: 
-      single_page: 
-      single_page_html: 
+      single_page:
+        one: 
+        other: 
+      single_page_html:
+        one: 
+        other: 
     page_gap: 
     previous_label: 

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,4 +1,7 @@
+---
 it:
+  active_admin:
+    dashboard: 
   activemodel:
     attributes:
       contact:
@@ -13,7 +16,7 @@ it:
         empty: non può essere vuoto
         equal_to: deve essere uguale a %{count}
         even: deve essere pari
-        exclusion: "è riservato"
+        exclusion: è riservato
         greater_than: deve essere superiore a %{count}
         greater_than_or_equal_to: deve essere superiore o uguale a %{count}
         inclusion: non è incluso nella lista
@@ -27,16 +30,16 @@ it:
         restrict_dependent_destroy:
           one: Non è possibile cancellare il registro perché esiste un %{record} dipendente
           other: Non è possibile cancellare il registro perché esistono %{record} dipendente
-        taken: "è già in uso"
+        taken: è già in uso
         too_long:
-          one: "è troppo lungo (il massimo è 1 carattere)"
-          other: "è troppo lungo (il massimo è %{count} caratteri)"
+          one: è troppo lungo (il massimo è 1 carattere)
+          other: è troppo lungo (il massimo è %{count} caratteri)
         too_short:
-          one: "è troppo corto (il minimo è 1 carattere)"
-          other: "è troppo corto (il minimo è %{count} caratteri)"
+          one: è troppo corto (il minimo è 1 carattere)
+          other: è troppo corto (il minimo è %{count} caratteri)
         wrong_length:
-          one: "è della lunghezza sbagliata (deve essere di 1 carattere)"
-          other: "è della lunghezza sbagliata (deve essere di %{count} caratteri)"
+          one: è della lunghezza sbagliata (deve essere di 1 carattere)
+          other: è della lunghezza sbagliata (deve essere di %{count} caratteri)
       template:
         body: 'Per favore ricontrolla i seguenti campi:'
         header:
@@ -52,6 +55,9 @@ it:
         subject: Titolo
         title: Titolo
         type: Tipo
+      contact:
+        email: 
+        message: 
       message:
         subject: Soggetto
       user:
@@ -72,7 +78,7 @@ it:
         empty: non può essere vuoto
         equal_to: deve essere uguale a %{count}
         even: deve essere pari
-        exclusion: "è riservato"
+        exclusion: è riservato
         greater_than: deve essere superiore a %{count}
         greater_than_or_equal_to: deve essere superiore o uguale a %{count}
         inclusion: non è incluso nella lista
@@ -86,16 +92,16 @@ it:
         restrict_dependent_destroy:
           one: No è possibile cancellare il registro perché esiste un %{record} dipendente
           other: Non è possibile cancellare il registro perché esistono %{record} dipendenti
-        taken: "è già in uso"
+        taken: è già in uso
         too_long:
-          one: "è troppo lungo (il massimo è 1 carattere)"
-          other: "è troppo lungo (il massimo è %{count} caratteri)"
+          one: è troppo lungo (il massimo è 1 carattere)
+          other: è troppo lungo (il massimo è %{count} caratteri)
         too_short:
-          one: "è troppo corto (il minimo è 1 carattere)"
-          other: "è troppo corto (il minimo è %{count} caratteri)"
+          one: è troppo corto (il minimo è 1 carattere)
+          other: è troppo corto (il minimo è %{count} caratteri)
         wrong_length:
-          one: "è della lunghezza sbagliata (deve essere di 1 carattere)"
-          other: "è della lunghezza sbagliata (deve essere di %{count} caratteri)"
+          one: è della lunghezza sbagliata (deve essere di 1 carattere)
+          other: è della lunghezza sbagliata (deve essere di %{count} caratteri)
       template:
         body: 'Per favore ricontrolla i seguenti campi:'
         header:
@@ -221,12 +227,19 @@ it:
       reset_password_instructions:
         subject: Istruzioni per reimpostare la password
       unlock_instructions:
+        action: 
+        greeting: 
+        instruction: 
+        message: 
         subject: Istruzioni per sbloccare l'account
     omniauth_callbacks:
       failure: Non è stato possibile autorizzarti da %{kind} perchè "%{reason}".
       success: Autorizzato con successo dall'account %{kind}.
     passwords:
       action: Cambia la password
+      edit:
+        confirm_new_password: 
+        new_password: 
       follow_instructions: 'Qualcuno a chiesto di cambiare la password di nolotiro.org. Se non sei stato tu puoi ignorare questa email. La password non cambierà fino a quando non accedi al link per crearne una nuova. '
       forgot: Hai dimenticato la password?
       instructions: Per favore, scrive la tua email e te invieremo un link di acceso diretto per cambiare la tua password.
@@ -250,6 +263,8 @@ it:
       user:
         signed_in: Acceso eseguito
     unlocks:
+      new:
+        resend_unlock_instructions: 
       send_instructions: Riceverai un messaggio email con le istruzioni per sbloccare il tuo account entro qualche minuto.
       send_paranoid_instructions: Se la tua e-mail esiste nel nostro database, riceverai un messaggio email con le istruzioni per sbloccare il tuo account entro qualche minuto.
       unlocked: Il tuo account è stato correttamente sbloccato. Ora sei collegato.
@@ -257,15 +272,15 @@ it:
     format: "%{attribute} %{message}"
     messages:
       accepted: deve essere accettata
-      already_confirmed: "è stato già confermato"
+      already_confirmed: è stato già confermato
       blank: non può essere lasciato in bianco
       confirmation: non coincide con la conferma
       confirmation_period_expired: deve essere confermato entro %{period}, richiedi una nuova conferma
       empty: non può essere vuoto
       equal_to: deve essere uguale a %{count}
       even: deve essere pari
-      exclusion: "è riservato"
-      expired: "è scaduto, si prega di richiederne uno nuovo"
+      exclusion: è riservato
+      expired: è scaduto, si prega di richiederne uno nuovo
       greater_than: deve essere superiore a %{count}
       greater_than_or_equal_to: deve essere superiore o uguale a %{count}
       inclusion: non è incluso nella lista
@@ -284,16 +299,16 @@ it:
       restrict_dependent_destroy:
         one: Non si può cancellare il registro perché esiste un %{record} dipendente
         other: Non si può cancellare il registro perché esistono %{record} dipendente
-      taken: "è già in uso"
+      taken: è già in uso
       too_long:
-        one: "è troppo lungo (il massimo è 1 carattere)"
-        other: "è troppo lungo (il massimo è %{count} caratteri)"
+        one: è troppo lungo (il massimo è 1 carattere)
+        other: è troppo lungo (il massimo è %{count} caratteri)
       too_short:
-        one: "è troppo corto (il minimo è 1 carattere)"
-        other: "è troppo corto (il minimo è %{count} caratteri)"
+        one: è troppo corto (il minimo è 1 carattere)
+        other: è troppo corto (il minimo è %{count} caratteri)
       wrong_length:
-        one: "è della lunghezza sbagliata (deve essere di 1 carattere)"
-        other: "è della lunghezza sbagliata (deve essere di %{count} caratteri)"
+        one: è della lunghezza sbagliata (deve essere di 1 carattere)
+        other: è della lunghezza sbagliata (deve essere di %{count} caratteri)
     template:
       body: 'Per favore ricontrolla i seguenti campi:'
       header:
@@ -327,9 +342,11 @@ it:
       you_have_new_message: Hai ricevuto un nuovo messaggio
       you_have_recieved_new_message: Hai ricevuto un nuovo messaggio
     new:
+      body_max: 
       button: Invia
       errors: 'C''è stato un problema, controlla questo:'
       legend: Invia il messaggio
+      subject: 
       submit: Invia
       title: Nuovo messaggio privato per l'utente %{user}
     notification_mailer:
@@ -374,6 +391,7 @@ it:
       lock_user: "[ADMIN] Bloccare a questo utente"
       unlock_user: "[ADMIN] Sbloccare a questo utente"
     ads:
+      bumped: 
       created: 'Abbiamo creato l''annuncio '
       form:
         body: Corpo del annuncio
@@ -397,6 +415,7 @@ it:
     back: torna alla pagina iniziale
     blog: blog
     booked: riservato
+    bump_this_ad: 
     by_user: per l'utente
     cancel_my_account: Cancella il mio account
     captcha_error: 'Forse hai sbagliato a scrivere i caratteri del captcha visto che non coincidono con l''immagine, provaci ancora  '
@@ -415,6 +434,7 @@ it:
     cities_in_the_world: città del mondo che reciclano di piu
     click_to_large: Clicca per ingrandire la foto
     comments:
+      body_max: 
       do_click: 'Clicca sul link per rispondere al messaggio:'
       flash_ko: Si è verificato un errore durante il salvataggio il tuo commento. Controllare e rinviarlo
       flash_ok: Commento salvato
@@ -470,6 +490,10 @@ it:
     keywords: regalato seconda mano gratis
     last_published_gifts: ultimi regali pubblicati
     leave_blank: "(Lasciala in bianco se non la vuoi cambiare)"
+    legal_notice: 
+    legal_page:
+      body_html: 
+      title: 
     login: accedi
     login_to_comment: l'accesso a scrivere un commento
     logout: uscire
@@ -487,6 +511,7 @@ it:
     new_user: nuovo utente
     no_results:
       explain_html: 
+      on_user: 
       phrase: 
       publish_ad: pubblicare un annuncio in questa città
       subtitle: Si può provare una qualsiasi di queste cose
@@ -529,6 +554,7 @@ it:
     send: Inviare
     send_a_message: "+ Invia un messaggio privato a inserzionista"
     send_a_message_to: 'envia un messaggio privato a '
+    send_a_private_message: 
     sending_this_form: Inviando questo modulo, ammette di aver letto, compreso, e si è soddisfatti con il nostro
     share_this_ad: Condividi questo annuncio
     sign_in: Login
@@ -555,6 +581,7 @@ it:
     users_most_active_last_week: 
     view_ads_on: 
     view_ads_on_your_city: Mostra annunci nella vostra città o paese
+    view_more_ads: 
     want: ricerca
     want_to_leave: 
     we_need_your_password: 
@@ -634,7 +661,11 @@ it:
     page_entries_info:
       multi_page: 
       multi_page_html: 
-      single_page: 
-      single_page_html: 
+      single_page:
+        one: 
+        other: 
+      single_page_html:
+        one: 
+        other: 
     page_gap: "&hellip;"
     previous_label: "← precedente"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -415,17 +415,17 @@ it:
     cities_in_the_world: città del mondo che reciclano di piu
     click_to_large: Clicca per ingrandire la foto
     comments:
-      do_click: 
-      flash_ko: 
-      flash_ok: 
-      label: 
+      do_click: 'Clicca sul link per rispondere al messaggio:'
+      flash_ko: Si è verificato un errore durante il salvataggio il tuo commento. Controllare e rinviarlo
+      flash_ok: Commento salvato
+      label: Il tuo commento
       subject: 
-      submit: 
-      title: 
+      submit: Inviare
+      title: Commenti
     comments_count:
       one: ", %{count} commento"
       other: ", %{count} commenti"
-    contact: 
+    contact: contatto
     contact_form: Formulario di contatto
     contact_legend: Per favore, scrive il tuo messaggio
     contact_thanks: Messaggio inviato! Grazie per contattare con nolotiro.org
@@ -446,11 +446,11 @@ it:
       answer_5_html: 
       answer_6_html: 
       answer_7_html: 
-      question_1: 
-      question_2: 
-      question_3: 
+      question_1: Qual è il fine di questo progetto?
+      question_2: Quindi ... Questo sito non è quello di aiutare gli altri?
+      question_3: Ma mi piace dare la mia roba a qualcuno che veramente ne ha bisogno
       question_4: 
-      question_5: 
+      question_5: Che tipo di annunci posso pubblicare in nolotiro?
       question_6: Non è permesso il scambio di oggetti? che strano
       question_7: Posso inviare cose a gente che non abita nella mia città?
       title: Domande frequenti
@@ -471,34 +471,34 @@ it:
     last_published_gifts: ultimi regali pubblicati
     leave_blank: "(Lasciala in bianco se non la vuoi cambiare)"
     login: accedi
-    login_to_comment: 
-    logout: 
+    login_to_comment: l'accesso a scrivere un commento
+    logout: uscire
     mail:
-      automatic: 
-    member_since: 
-    messages: 
+      automatic: Questo è un messaggio automatico. Si prega di non rispondere a questo indirizzo email.
+    member_since: membro dal
+    messages: messaggi
     messages_tabs:
-      inbox: 
-      sent: 
-      trash: 
-    messages_title: 
+      inbox: ricevuto
+      sent: Inviati
+      trash: Cestino
+    messages_title: Messaggi
     meta_description: 
-    meta_description_ad: 
-    new_user: 
+    meta_description_ad: rivendita regali %{title} en %{woeid}. %{body}
+    new_user: nuovo utente
     no_results:
       explain_html: 
       phrase: 
-      publish_ad: 
-      subtitle: 
-      title: 
-      try: 
-    or: 
-    password: 
-    permission_denied: 
-    please_fill_to_become_member: 
-    please_insert_email_and_password: 
-    please_introduce: 
-    privacy: 
+      publish_ad: pubblicare un annuncio in questa città
+      subtitle: Si può provare una qualsiasi di queste cose
+      title: Nessun annuncio per questa posizione.
+      try: 'Oppure provate queste città con nome simile:'
+    or: o
+    password: password
+    permission_denied: Non si dispone dell'autorizzazione per eseguire questa azione.
+    please_fill_to_become_member: Si prega di compilare questo modulo per essere un membro di nolotiro
+    please_insert_email_and_password: Metta prego la tua email e la password.
+    please_introduce: 'Inserisci i caratteri che vedi:'
+    privacy: politica sulla privacy
     privacy_page:
       body_html: 
       title: 
@@ -509,43 +509,43 @@ it:
         delete: 
     profile_edit: 
     publish_ad: 
-    publish_ad_on: 
-    published_ads: 
-    published_at_by_html: 
-    published_on: 
-    published_on_html: 
-    readed_count: 
-    reads: 
-    register: 
-    register_here: 
-    remember_me: 
+    publish_ad_on: Inserisci annunci a %{woeid}
+    published_ads: annunci pubblicati
+    published_at_by_html: Pubblicato fa %{time} dall'utente %{user}
+    published_on: Pubblicato fa %{date}
+    published_on_html: Pubblicato <abbr class='js-moment' title='%{date}'>%{date}</abbr>
+    readed_count: "%{count} lettures"
+    reads: lettures
+    register: Iscriviti
+    register_here: registrati qui
+    remember_me: Ricordare il login
     rss_suscribe: 
     save_failed: 
     search:
-      button: 
-      must_search: 
+      button: ricerca
+      must_search: Si dovrebbe cercare qualcosa da qualche parte.
       no_ads_message_html: 
     searching_on_html: 
-    send: 
-    send_a_message: 
-    send_a_message_to: 
-    sending_this_form: 
-    share_this_ad: 
-    sign_in: 
-    sign_in_with_provider: 
-    sign_up: 
-    slogan: 
-    suggestions: 
-    to_publish_ad: 
+    send: Inviare
+    send_a_message: "+ Invia un messaggio privato a inserzionista"
+    send_a_message_to: 'envia un messaggio privato a '
+    sending_this_form: Inviando questo modulo, ammette di aver letto, compreso, e si è soddisfatti con il nostro
+    share_this_ad: Condividi questo annuncio
+    sign_in: Login
+    sign_in_with_provider: Accedi con un altro provider
+    sign_up: Creare un utente
+    slogan: Non buttare, io regalo (senza condizioni)
+    suggestions: suggerimenti
+    to_publish_ad: Pubblicare anuncio
     to_publish_or_send_messages: 
-    tos: 
+    tos: condizioni di utilizzo
     tos_page:
-      body_html: 
-      title: 
+      body_html: TODO
+      title: Condizioni di utilizzo
     translate:
       description_html: 
-      title: 
-    update: 
+      title: Aiutaci a tradurre nolotiro.org la lingua
+    update: salvare
     updating: 
     user_ads: 
     user_edit_profile: 
@@ -554,14 +554,14 @@ it:
     users_most_active: 
     users_most_active_last_week: 
     view_ads_on: 
-    view_ads_on_your_city: 
-    want: 
+    view_ads_on_your_city: Mostra annunci nella vostra città o paese
+    want: ricerca
     want_to_leave: 
     we_need_your_password: 
-    welcome: 
-    welcome_message: 
-    write_a_comment: 
-    your_email: 
+    welcome: ciao
+    welcome_message: Benvenuti
+    write_a_comment: "+ Scrivi un commento"
+    your_email: la tua email
   number:
     currency:
       format:
@@ -611,7 +611,7 @@ it:
         delimiter: 
   recaptcha:
     errors:
-      incorrect-captcha-sol: 
+      incorrect-captcha-sol: C'è stato un errore riempire i caratteri captcha.
       verification_failed: 
   support:
     array:
@@ -628,7 +628,7 @@ it:
   unauthorized:
     default: 
     manage:
-      all: 
+      all: "È necessario prima effettuare il login o registrare un utente."
   will_paginate:
     next_label: successivo →
     page_entries_info:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,4 +1,7 @@
+---
 nl:
+  active_admin:
+    dashboard: 
   activemodel:
     attributes:
       contact:
@@ -31,7 +34,9 @@ nl:
         wrong_length: 
       template:
         body: 
-        header: 
+        header:
+          one: 
+          other: 
   activerecord:
     attributes:
       ad:
@@ -42,6 +47,9 @@ nl:
         subject: 
         title: 
         type: 
+      contact:
+        email: 
+        message: 
       message:
         subject: 
       user:
@@ -80,7 +88,9 @@ nl:
         wrong_length: 
       template:
         body: 
-        header: 
+        header:
+          one: 
+          other: 
   date:
     abbr_day_names:
     - zon
@@ -142,14 +152,22 @@ nl:
       about_x_months:
         one: rond 1 maand
         other: ongeveer %{count} manden
-      about_x_years: 
+      about_x_years:
+        one: 
+        other: 
       almost_x_years:
         one: bijna 1 jaar
         other: bijna %{count} jaar
       half_a_minute: 
-      less_than_x_minutes: 
-      less_than_x_seconds: 
-      over_x_years: 
+      less_than_x_minutes:
+        one: 
+        other: 
+      less_than_x_seconds:
+        one: 
+        other: 
+      over_x_years:
+        one: 
+        other: 
       x_days:
         one: 1 dag
         other: "%{count} dagen"
@@ -159,7 +177,9 @@ nl:
       x_months:
         one: 1 maand
         other: "%{count} manden"
-      x_seconds: 
+      x_seconds:
+        one: 
+        other: 
     prompts:
       day: Dag
       hour: Uur
@@ -191,12 +211,19 @@ nl:
       reset_password_instructions:
         subject: 
       unlock_instructions:
+        action: 
+        greeting: 
+        instruction: 
+        message: 
         subject: 
     omniauth_callbacks:
       failure: 
       success: 
     passwords:
       action: 
+      edit:
+        confirm_new_password: 
+        new_password: 
       follow_instructions: 
       forgot: 
       instructions: 
@@ -220,6 +247,8 @@ nl:
       user:
         signed_in: 
     unlocks:
+      new:
+        resend_unlock_instructions: 
       send_instructions: 
       send_paranoid_instructions: 
       unlocked: 
@@ -246,17 +275,23 @@ nl:
       not_an_integer: 
       not_found: 
       not_locked: 
-      not_saved: 
+      not_saved:
+        one: 
+        other: 
       odd: 
       record_invalid: 
-      restrict_dependent_destroy: 
+      restrict_dependent_destroy:
+        one: 
+        other: 
       taken: 
       too_long: 
       too_short: 
       wrong_length: 
     template:
       body: 
-      header: 
+      header:
+        one: 
+        other: 
   helpers:
     label:
       message:
@@ -285,9 +320,11 @@ nl:
       you_have_new_message: 
       you_have_recieved_new_message: 
     new:
+      body_max: 
       button: 
       errors: 
       legend: 
+      subject: 
       submit: 
       title: 
     notification_mailer:
@@ -332,6 +369,7 @@ nl:
       lock_user: 
       unlock_user: 
     ads:
+      bumped: 
       created: 
       form:
         body: 
@@ -355,6 +393,7 @@ nl:
     back: 
     blog: 
     booked: 
+    bump_this_ad: 
     by_user: 
     cancel_my_account: 
     captcha_error: 
@@ -373,6 +412,7 @@ nl:
     cities_in_the_world: 
     click_to_large: 
     comments:
+      body_max: 
       do_click: 
       flash_ko: 
       flash_ok: 
@@ -380,7 +420,9 @@ nl:
       subject: 
       submit: 
       title: 
-    comments_count: 
+    comments_count:
+      one: 
+      other: 
     contact: 
     contact_form: 
     contact_legend: 
@@ -426,6 +468,10 @@ nl:
     keywords: 
     last_published_gifts: 
     leave_blank: 
+    legal_notice: 
+    legal_page:
+      body_html: 
+      title: 
     login: 
     login_to_comment: 
     logout: 
@@ -443,6 +489,7 @@ nl:
     new_user: 
     no_results:
       explain_html: 
+      on_user: 
       phrase: 
       publish_ad: 
       subtitle: 
@@ -485,6 +532,7 @@ nl:
     send: 
     send_a_message: 
     send_a_message_to: 
+    send_a_private_message: 
     sending_this_form: 
     share_this_ad: 
     sign_in: 
@@ -511,6 +559,7 @@ nl:
     users_most_active_last_week: 
     view_ads_on: 
     view_ads_on_your_city: 
+    view_more_ads: 
     want: 
     want_to_leave: 
     we_need_your_password: 
@@ -590,7 +639,11 @@ nl:
     page_entries_info:
       multi_page: 
       multi_page_html: 
-      single_page: 
-      single_page_html: 
+      single_page:
+        one: 
+        other: 
+      single_page_html:
+        one: 
+        other: 
     page_gap: 
     previous_label: 

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,4 +1,7 @@
+---
 pt:
+  active_admin:
+    dashboard: 
   activemodel:
     attributes:
       contact:
@@ -13,11 +16,11 @@ pt:
         empty: não pode estar vazio
         equal_to: tem de ser igual a %{count}
         even: tem de ser par
-        exclusion: "é reservado"
+        exclusion: é reservado
         greater_than: tem de ser maior que %{count}
         greater_than_or_equal_to: tem de ser maior ou igual a %{count}
         inclusion: não está incluído na lista
-        invalid: "é inválido"
+        invalid: é inválido
         less_than: tem de ser menor que %{count}
         less_than_or_equal_to: tem de ser menor ou igual a %{count}
         not_a_number: não é um número
@@ -26,8 +29,8 @@ pt:
         record_invalid: 'A validação falhou: %{errors}'
         restrict_dependent_destroy: 
         taken: não está disponível
-        too_long: "é demasiado grande (o máximo é de %{count} caracteres)"
-        too_short: "é demasiado pequeno (o mínimo é de %{count} caracteres)"
+        too_long: é demasiado grande (o máximo é de %{count} caracteres)
+        too_short: é demasiado pequeno (o mínimo é de %{count} caracteres)
         wrong_length: comprimento errado (deve ter %{count} caracteres)
       template:
         body: 'Por favor, verifique os seguintes campos:'
@@ -44,6 +47,9 @@ pt:
         subject: 
         title: 
         type: 
+      contact:
+        email: 
+        message: 
       message:
         subject: 
       user:
@@ -64,11 +70,11 @@ pt:
         empty: não pode estar vazio
         equal_to: tem de ser igual a %{count}
         even: tem de ser par
-        exclusion: "é reservado"
+        exclusion: é reservado
         greater_than: tem de ser maior que %{count}
         greater_than_or_equal_to: tem de ser maior ou igual a %{count}
         inclusion: não está incluído na lista
-        invalid: "é inválido"
+        invalid: é inválido
         less_than: tem de ser menor que %{count}
         less_than_or_equal_to: tem de ser menor ou igual a %{count}
         not_a_number: não é um número
@@ -77,8 +83,8 @@ pt:
         record_invalid: 'A validação falhou: %{errors}'
         restrict_dependent_destroy: 
         taken: não está disponível
-        too_long: "é demasiado grande (o máximo é de %{count} caracteres)"
-        too_short: "é demasiado pequeno (o mínimo é de %{count} caracteres)"
+        too_long: é demasiado grande (o máximo é de %{count} caracteres)
+        too_short: é demasiado pequeno (o mínimo é de %{count} caracteres)
         wrong_length: comprimento errado (deve ter %{count} caracteres)
       template:
         body: 'Por favor, verifique os seguintes campos:'
@@ -205,12 +211,19 @@ pt:
       reset_password_instructions:
         subject: Instruções de recuperação de palavra-passe
       unlock_instructions:
+        action: 
+        greeting: 
+        instruction: 
+        message: 
         subject: Instruções de desbloqueio
     omniauth_callbacks:
       failure: Could not authorize you from %{kind} because "%{reason}".
       success: Successfully authorized from %{kind} account.
     passwords:
       action: 
+      edit:
+        confirm_new_password: 
+        new_password: 
       follow_instructions: 
       forgot: 
       instructions: 
@@ -234,6 +247,8 @@ pt:
       user:
         signed_in: 
     unlocks:
+      new:
+        resend_unlock_instructions: 
       send_instructions: Dentro de alguns minutos irá receber um email com as instruções para desbloquear a sua conta.
       send_paranoid_instructions: Se a sua conta existir, irá receber dentro de alguns minutos um email com instruções para a desbloquear.
       unlocked: A sua conta foi desbloqueada com sucesso. Agora está autenticado.
@@ -248,12 +263,12 @@ pt:
       empty: não pode estar vazio
       equal_to: tem de ser igual a %{count}
       even: tem de ser par
-      exclusion: "é reservado"
+      exclusion: é reservado
       expired: expirou, por favor solicite um novo
       greater_than: tem de ser maior que %{count}
       greater_than_or_equal_to: tem de ser maior ou igual a %{count}
       inclusion: não está incluído na lista
-      invalid: "é inválido"
+      invalid: é inválido
       less_than: tem de ser menor que %{count}
       less_than_or_equal_to: tem de ser menor ou igual a %{count}
       not_a_number: não é um número
@@ -265,10 +280,12 @@ pt:
         other: "%{count} erros impediram %{resource} de ser gravado:"
       odd: tem de ser ímpar
       record_invalid: 'A validação falhou: %{errors}'
-      restrict_dependent_destroy: 
+      restrict_dependent_destroy:
+        one: 
+        other: 
       taken: não está disponível
-      too_long: "é demasiado grande (o máximo é de %{count} caracteres)"
-      too_short: "é demasiado pequeno (o mínimo é de %{count} caracteres)"
+      too_long: é demasiado grande (o máximo é de %{count} caracteres)
+      too_short: é demasiado pequeno (o mínimo é de %{count} caracteres)
       wrong_length: comprimento errado (deve ter %{count} caracteres)
     template:
       body: 'Por favor, verifique os seguintes campos:'
@@ -303,9 +320,11 @@ pt:
       you_have_new_message: 
       you_have_recieved_new_message: 
     new:
+      body_max: 
       button: 
       errors: 
       legend: 
+      subject: 
       submit: 
       title: 
     notification_mailer:
@@ -350,6 +369,7 @@ pt:
       lock_user: 
       unlock_user: 
     ads:
+      bumped: 
       created: 
       form:
         body: 
@@ -373,6 +393,7 @@ pt:
     back: 
     blog: 
     booked: 
+    bump_this_ad: 
     by_user: 
     cancel_my_account: 
     captcha_error: 
@@ -391,6 +412,7 @@ pt:
     cities_in_the_world: 
     click_to_large: 
     comments:
+      body_max: 
       do_click: 
       flash_ko: 
       flash_ok: 
@@ -398,7 +420,9 @@ pt:
       subject: 
       submit: 
       title: 
-    comments_count: 
+    comments_count:
+      one: 
+      other: 
     contact: 
     contact_form: 
     contact_legend: 
@@ -444,6 +468,10 @@ pt:
     keywords: 
     last_published_gifts: 
     leave_blank: 
+    legal_notice: 
+    legal_page:
+      body_html: 
+      title: 
     login: 
     login_to_comment: 
     logout: 
@@ -461,6 +489,7 @@ pt:
     new_user: 
     no_results:
       explain_html: 
+      on_user: 
       phrase: 
       publish_ad: 
       subtitle: 
@@ -503,6 +532,7 @@ pt:
     send: 
     send_a_message: 
     send_a_message_to: 
+    send_a_private_message: 
     sending_this_form: 
     share_this_ad: 
     sign_in: 
@@ -529,6 +559,7 @@ pt:
     users_most_active_last_week: 
     view_ads_on: 
     view_ads_on_your_city: 
+    view_more_ads: 
     want: 
     want_to_leave: 
     we_need_your_password: 
@@ -616,7 +647,11 @@ pt:
     page_entries_info:
       multi_page: Mostrando %{model} %{from} - %{to} de %{count} no total
       multi_page_html: Mostrando %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> de <b>%{count}</b> no total
-      single_page: 
-      single_page_html: 
+      single_page:
+        one: 
+        other: 
+      single_page_html:
+        one: 
+        other: 
     page_gap: "&hellip;"
     previous_label: "← anterior"


### PR DESCRIPTION
Tres cambios:

- Actualiza los ficheros con claves que ha traducido @iokese en localeapp
- Añade claves vacías en los lugares donde faltaban para localeapp las vea como no traducidas. Hay otros cambios poco significativos (como quitar comillas) que ha generado automáticamente la herramienta que he utilizado (`i18n-tasks`).
- Normaliza la configuración de fallbacks de i18n en todos los entornos. Esto último no lo tengo claro, la idea es que los developers nos centremos en desarollar y no nos despistemos con claves no traducidas, pero tampoco tengo claro del todo que sea un buen cambio.