### PR TITLE
Fix tests with seed 34007

### DIFF
--- a/test/integration/can_access_admin_test.rb
+++ b/test/integration/can_access_admin_test.rb
@@ -1,7 +1,9 @@
 require "test_helper"
-include Warden::Test::Helpers
+require "integration/concerns/authentication"
 
 class CanAccessAdmin < ActionDispatch::IntegrationTest
+  include Authentication
+
   it "should not get /admin/jobs as a anonymous user" do
     visit "/admin/jobs"
     page.must_have_content "Para publicar anuncios o enviar mensajes accede a tu cuenta"

--- a/test/integration/can_access_admin_test.rb
+++ b/test/integration/can_access_admin_test.rb
@@ -10,14 +10,12 @@ class CanAccessAdmin < ActionDispatch::IntegrationTest
   end
 
   it "should not get /admin/jobs as a normal user" do
-    @user = FactoryGirl.create(:user)
-    login_as @user
+    login_as user
     assert_raises(ActionController::RoutingError) { visit "/admin/jobs" }
   end
 
   it "should get /admin/jobs as admin" do
-    @admin = FactoryGirl.create(:admin)
-    login_as @admin
+    login_as admin
     visit "/admin/jobs"
     page.must_have_content "Sidekiq"
     page.must_have_content "Redis"
@@ -30,17 +28,24 @@ class CanAccessAdmin < ActionDispatch::IntegrationTest
   end
 
   it "should not get /admin as a normal user" do
-    @user = FactoryGirl.create(:user)
-    login_as @user
+    login_as user
     visit "/admin"
     page.must_have_content I18n.t('nlt.permission_denied')
   end
 
   it "should get /admin as admin" do
-    @admin = FactoryGirl.create(:admin)
-    login_as @admin
+    login_as admin
     visit "/admin"
     page.must_have_content "Últimos anuncios publicados"
   end
 
+  private
+
+  def user
+    @user ||= FactoryGirl.create(:user)
+  end
+
+  def admin
+    @admin ||= FactoryGirl.create(:admin)
+  end
 end

--- a/test/integration/can_user_message_test.rb
+++ b/test/integration/can_user_message_test.rb
@@ -5,12 +5,12 @@ class CanUserMessage < ActionDispatch::IntegrationTest
   include Authentication
 
   before do
-    @user1 = FactoryGirl.create(:user)
-    @user2 = FactoryGirl.create(:user)
+    user1 = FactoryGirl.create(:user)
+    user2 = FactoryGirl.create(:user)
 
-    login_as @user1
+    login_as user1
 
-    visit message_new_path(@user2)
+    visit message_new_path(user2)
   end
 
   it "should message another user" do

--- a/test/integration/can_user_message_test.rb
+++ b/test/integration/can_user_message_test.rb
@@ -1,7 +1,9 @@
 require "test_helper"
-include Warden::Test::Helpers
+require "integration/concerns/authentication"
 
 class CanUserMessage < ActionDispatch::IntegrationTest
+  include Authentication
+
   before do
     @user1 = FactoryGirl.create(:user)
     @user2 = FactoryGirl.create(:user)

--- a/test/integration/edition_by_admin_test.rb
+++ b/test/integration/edition_by_admin_test.rb
@@ -6,8 +6,8 @@ class EditionsByAdmin < ActionDispatch::IntegrationTest
 
   before do
     @ad = FactoryGirl.create(:ad, woeid_code: 766273, type: 1)
-    @admin = FactoryGirl.create(:admin, woeid: 766272)
-    login_as @admin
+    admin = FactoryGirl.create(:admin, woeid: 766272)
+    login_as admin
   end
 
   it "changes only the edited attribute" do

--- a/test/integration/edition_by_admin_test.rb
+++ b/test/integration/edition_by_admin_test.rb
@@ -1,7 +1,9 @@
 require "test_helper"
-include Warden::Test::Helpers
+require "integration/concerns/authentication"
 
 class EditionsByAdmin < ActionDispatch::IntegrationTest
+  include Authentication
+
   before do
     @ad = FactoryGirl.create(:ad, woeid_code: 766273, type: 1)
     @admin = FactoryGirl.create(:admin, woeid: 766272)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,4 +34,8 @@ end
 class ActionDispatch::IntegrationTest
   # Make the Capybara DSL available in all integration tests
   include Capybara::DSL
+
+  after do
+    Capybara.reset_sessions!
+  end
 end


### PR DESCRIPTION
Ayer @jipipayo actualizó la PR #178 con los últimos cambios en master y CI falló. El fallo no tiene nada que ver con los cambios de la PR y se puede reproducir con `bundle exec rake test TESTOPTS="--seed=34007"`, que escupe:

```
  1) Error:
AuthenticatedAdListing#test_0004_lists delivered ads in users location in home page:
ActionController::RoutingError: No route matches [GET] "/admin/jobs"
    test/integration/concerns/authentication.rb:8:in `login'
    test/integration/authenticated_ad_listing_test.rb:17:in `block (2 levels) in <class:AuthenticatedAdListing>'
    test/integration/concerns/pagination.rb:6:in `with_pagination'
    test/integration/authenticated_ad_listing_test.rb:17:in `block in <class:AuthenticatedAdListing>'
```

Esta PR lo arregla, y también introduce algunos cambios menores en los tests que añadí mientras investigaba el fallo.