### PR TITLE
Seed improvements

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,11 +1,11 @@
 # coding: utf-8
 
-def create_user(role = 0, email = Faker::Internet.email, username = Faker::Name.name)
+def create_user(role = 0)
   pwd = '12345678'
   puts "    #{email}"
   User.create!(
-    username: username,
-    email: email,
+    username: Faker::Name.name,
+    email: Faker::Internet.email,
     role: role,
     password: pwd,
     password_confirmation: pwd,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,16 +3,19 @@
 def create_user(role = 0)
   pwd = '12345678'
   puts "    #{email}"
-  User.create!(
-    username: Faker::Name.name,
-    email: Faker::Internet.email,
-    role: role,
-    password: pwd,
-    password_confirmation: pwd,
-    confirmed_at: Time.now,
-    lang: 'es',
-    woeid: 766273
-  )
+  loop do
+    user = User.new(
+      username: Faker::Name.name,
+      email: Faker::Internet.email,
+      role: role,
+      password: pwd,
+      password_confirmation: pwd,
+      confirmed_at: Time.now,
+      lang: 'es',
+      woeid: 766_273
+    )
+    return user if user.save
+  end
 end
 
 def create_ad(user)


### PR DESCRIPTION
Hace un rato las seeds me han fallado porque a veces intentan insertar nombres de usuario más largos de lo que soporta la columna. Éste es el error:

```
rake aborted!
ActiveRecord::StatementInvalid: Mysql2::Error: Data too long for column 'username' at row 1: INSERT INTO `users` (`username`, `email`, `encrypted_password`, `confirmed_at`, `lang`, `created_at`) VALUES ('Sra. Juan Carlos Camarillo Gollum', 'brook.greenholt@cain.com', '$2a$10$wIBfJVddXcsOis4SqGhz1OHYw4GFuYwo6POn8tk4lFzzah3fWmu/e', '2016-04-07 14:00:49', 'es', '2016-04-07')
```

Esta PR lo arregla.