### PR TITLE
[ads] Fix issue with rankings

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ActiveRecord::Base
   end
 
   scope :top_last_week, ->(limit = 20) do
-    top_overall.where("published_at >= :date", date: 1.week.ago)
+    top_overall(limit).where("published_at >= :date", date: 1.week.ago)
   end
 
   def self.from_omniauth(auth) 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -122,6 +122,13 @@ class UserScopesTest < ActiveSupport::TestCase
     assert_count(results.second, user2.id, user2.username, 2)
   end
 
+  test 'top last week accepts argument with number of publishers requested' do
+    results = User.top_last_week(1)
+
+    assert_equal(1, results.length)
+    assert_count(results.first, user1.id, user1.username, 3)
+  end
+
   private
 
   def assert_count(user, id, username, n_ads)


### PR DESCRIPTION
Parameter to `User#top_last_week` was not being respected.

El valor lo dejamos a 20 de todas formas.