### PR TITLE
Fix reset password form instructions

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -10,10 +10,10 @@
       <%= devise_error_messages! %>
       <%= f.hidden_field :reset_password_token %>
 
-  <div><%= f.label :password, t('.new_password', :default => 'New password') %><br />
+  <div><%= f.label :password %><br />
   <%= f.password_field :password %></div>
 
-  <div><%= f.label :password_confirmation, t('.confirm_new_password', :default => 'Confirm new password') %><br />
+  <div><%= f.label :password_confirmation %><br />
   <%= f.password_field :password_confirmation %></div>
 
       <div><%= f.submit t('devise.passwords.action') %></div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -7,8 +7,6 @@
 <div class="span-16">
   <%= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put }) do |f| %>
     <fieldset>
-      <p><%= t('devise.passwords.instructions') %>
-      </p>
       <%= devise_error_messages! %>
       <%= f.hidden_field :reset_password_token %>
 

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -229,7 +229,6 @@ ca:
         confirm_new_password: 
         new_password: 
       follow_instructions: Algú ha demanat canviar la teva contrasenya de nolotiro.org. Si no has estat pots ignorar aquest correu. La teva contrasenya no canviarà fins que accedeixis a l'enllaç i creïs una nova.
-      forgot: Has oblidat la teva contrasenya?
       instructions: Si us plau, introdueix el teu email i t'enviarem un enllaç d'accés directe per canviar la teva contrasenya.
       no_token: Només pots accedir a aquesta pàgina des d'un correu electrònic de recuperació de la contrasenya. Si realment has fet servir l'enllaç del correu electrònic, comprova que has utilitzat la URL completa.
       send: Envia per correu

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -225,7 +225,6 @@ de:
         confirm_new_password: 
         new_password: 
       follow_instructions: 
-      forgot: 
       instructions: 
       no_token: Sie können sich nicht auf dieser Seite anmelden, wenn Sie nicht von einer Passwort-Zurücksetzen-E-Mail kommen. Wenn Sie von solch einer E-Mail kommen, überprüfen Sie bitte, ob Sie die gesamte URL verwendeten.
       send: 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -221,7 +221,6 @@ en:
         confirm_new_password: 
         new_password: 
       follow_instructions: Someone asked nolotiro.org about change your password. If it's not you then you can ignore this mail. Your password will not change until you access the link and create a new one.
-      forgot: Did you forget your password?
       instructions: Please, enter your email address and we will send you a shortcut link to change your password.
       no_token: You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided.
       send: Send by email

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -229,7 +229,6 @@ es:
         confirm_new_password: 
         new_password: 
       follow_instructions: Alguien ha pedido cambiar tu contraseña de nolotiro.org. Si no has sido puedes ignorar este correo. Tu contraseña no cambiará hasta que accedas al enlace y crees una nueva.
-      forgot: "¿Has olvidado tu contraseña?"
       instructions: Por favor, introduce tu email y te enviaremos un enlace de acceso directo para cambiar tu contraseña.
       no_token: No puedes acceder a esta página si no es a través de un un enlace para resetear tu contraseña. Si has llegado hasta aquí desde el email para resetear tu contraseña, por favor asegúrate de que la URL introducida está completa.
       send: Enviar por correo

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -225,7 +225,6 @@ eu:
         confirm_new_password: 
         new_password: 
       follow_instructions: 
-      forgot: 
       instructions: 
       no_token: 
       send: 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -243,7 +243,6 @@ fr:
         confirm_new_password: 
         new_password: 
       follow_instructions: 
-      forgot: 
       instructions: 
       no_token: Vous ne pouvez pas accéder à cette page si vous n’y accédez pas depuis un email de réinitialisation de mot de passe. Si vous venez en effet d’un tel email, vérifiez que vous avez copié l’adresse URL en entier.
       send: 

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -228,7 +228,6 @@ gl:
         confirm_new_password: 
         new_password: 
       follow_instructions: 
-      forgot: 
       instructions: 
       no_token: 
       send: 

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -241,7 +241,6 @@ it:
         confirm_new_password: 
         new_password: 
       follow_instructions: 'Qualcuno a chiesto di cambiare la password di nolotiro.org. Se non sei stato tu puoi ignorare questa email. La password non cambierà fino a quando non accedi al link per crearne una nuova. '
-      forgot: Hai dimenticato la password?
       instructions: Per favore, scrive la tua email e te invieremo un link di acceso diretto per cambiare la tua password.
       no_token: Puoi accedere a questa pagina solamente dalla email di reset della password. Se vieni dalla email controlla di aver inserito l'url completo riportato nella email.
       send: Invia email

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -225,7 +225,6 @@ nl:
         confirm_new_password: 
         new_password: 
       follow_instructions: 
-      forgot: 
       instructions: 
       no_token: 
       send: 

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -225,7 +225,6 @@ pt:
         confirm_new_password: 
         new_password: 
       follow_instructions: 
-      forgot: 
       instructions: 
       no_token: Não pode aceder a esta página sem vir do email de redefinição da senha. Se vem dum email para redefinir a sena, por favor verifique que usou o URL completo que foi enviado.
       send: 


### PR DESCRIPTION
Ahora mismo se muestran unas instrucciones incorrectas en el formulario para fijar una nueva password:

![captura de pantalla de 2016-04-07 19 41 00](https://cloud.githubusercontent.com/assets/2887858/14360926/dc7cf68c-fcf8-11e5-9a53-ac644658bbcd.png)

