### PR TITLE
Admin console improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.0.0'
 gem 'therubyracer', platforms: :ruby
 gem 'jquery-rails'
-#gem 'turbolinks'
 gem 'jbuilder', '~> 1.2'
 gem 'rb-readline', '~> 0.5.0', :require => false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/activeadmin/activeadmin.git
-  revision: 44e6b83ad41b9332156e75db8434324dfad63960
+  revision: d84f8190edac8c28f942cd4b6c3e16086da9d7a2
   specs:
     activeadmin (1.0.0.pre2)
       arbre (~> 1.0, >= 1.0.2)
@@ -15,6 +15,7 @@ GIT
       rails (>= 3.2, < 5.0)
       ransack (~> 1.3)
       sass-rails
+      sprockets (< 4)
 
 GEM
   remote: https://rubygems.org/
@@ -157,9 +158,9 @@ GEM
       railties (>= 3.2, < 5.0)
     foreigner (1.7.4)
       activerecord (>= 3.0.0)
-    formtastic (3.1.3)
+    formtastic (3.1.4)
       actionpack (>= 3.2.13)
-    formtastic_i18n (0.4.1)
+    formtastic_i18n (0.6.0)
     geoip (1.6.1)
     geoplanet (0.2.7)
       json (>= 1.1.3)
@@ -203,8 +204,8 @@ GEM
       multi_json (>= 1.2.0)
     joiner (0.3.4)
       activerecord (>= 4.1.0)
-    jquery-rails (4.0.5)
-      rails-dom-testing (~> 1.0)
+    jquery-rails (4.1.1)
+      rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (5.0.5)
@@ -227,8 +228,8 @@ GEM
       ya2yaml
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mail (2.6.3)
-      mime-types (>= 1.16, < 3)
+    mail (2.6.4)
+      mime-types (>= 1.16, < 4)
     mailboxer (0.13.0)
       carrierwave (>= 0.5.8)
       foreigner (>= 0.9.1)
@@ -324,7 +325,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     raindrops (0.15.0)
-    rake (11.1.1)
+    rake (11.1.2)
     rakismet (1.5.1)
     ransack (1.7.0)
       actionpack (>= 3.0)
@@ -355,7 +356,7 @@ GEM
     redis-store (1.1.7)
       redis (>= 2.2)
     ref (2.0.0)
-    responders (2.1.1)
+    responders (2.1.2)
       railties (>= 4.2.0, < 5.1)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)

--- a/app/admin/ad.rb
+++ b/app/admin/ad.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Ad do
-  permit_params :woeid_code
+  permit_params :woeid_code, :type
 
   filter :title
   filter :body

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,7 +2,6 @@
 //= require jquery_ujs
 //= require jquery.cookiebar
 //= require moment-with-locales
-// require turbolinks
 //= require_tree .
 //
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -86,7 +86,7 @@
 
         <div class="site-logo">
           <div class="site-name">
-            <%= link_to root_path, :title => "nolotiro.org home", "data-no-turbolink" => true do %>
+            <%= link_to root_path, :title => "nolotiro.org home" do %>
               <%= image_tag "nolotiro_logo.png", :alt => "nolotiro.org", :id => "logo" %>
               nolotiro.org
               <%=h yield(:title) %>

--- a/app/views/partials/_user_actions.html.erb
+++ b/app/views/partials/_user_actions.html.erb
@@ -15,8 +15,8 @@
   </div>
 <% else %>
   <div class="user_login_box">
-    <%= link_to t('nlt.new_user'), new_user_registration_path, "data-no-turbolink" => true %>
+    <%= link_to t('nlt.new_user'), new_user_registration_path %>
     <%= t('nlt.or') %>
-    <%= link_to t('nlt.login'), new_user_session_path, "data-no-turbolink" => true %>
+    <%= link_to t('nlt.login'), new_user_session_path %>
   </div>
 <% end %>

--- a/app/views/partials/_you_have_to_sign_in.html.erb
+++ b/app/views/partials/_you_have_to_sign_in.html.erb
@@ -3,5 +3,5 @@
   <h1><%= t('nlt.to_publish_or_send_messages') %></h1>
   <br><br>
   (<%= t 'nlt.if_you_are_new' %>
-  <%= link_to t('nlt.register_here'), new_user_registration_path, "data-no-turbolink" => true, :title => "user register" %>)
+  <%= link_to t('nlt.register_here'), new_user_registration_path, :title => "user register" %>)
 </div>

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -122,7 +122,7 @@ ActiveAdmin.setup do |config|
   # config.comments = false
   #
   # You can disable the menu item for the comments index page:
-  config.show_comments_in_menu = false
+  config.comments_menu = false
   #
   # You can change the name under which comments are registered:
   # config.comments_registration_name = 'AdminComment'

--- a/test/integration/authenticated_ad_listing_test.rb
+++ b/test/integration/authenticated_ad_listing_test.rb
@@ -13,8 +13,10 @@ class AuthenticatedAdListing < ActionDispatch::IntegrationTest
     create(:ad, title: 'res_mad', woeid_code: 766_273, status: 2)
     create(:ad, title: 'del_mad', woeid_code: 766_273, status: 3)
 
-    @user = create(:user, woeid: 766_273)
-    with_pagination(1) { login(@user.email, @user.password) }
+    with_pagination(1) do
+      login_as create(:user, woeid: 766_273)
+      visit root_path
+    end
   end
 
   it 'lists first page of available ads in users location in home page' do


### PR DESCRIPTION
Aquí lo más importante es que permito la edición del tipo de anuncio desde la consola de administración (ahora mismo sólo se puede desde el link de "Editar anuncio" como administrador). Los otros cambios son algunas modificaciones que hice mientras investigaba este y otros temas de admin.