### PR TITLE
[deploy] Redeploy bins every time

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -15,7 +15,7 @@ set :deploy_via, :remote_cache
 set :ssh_options, { :forward_agent => true }
 
 set :linked_files, %w{config/database.yml config/secrets.yml config/newrelic.yml vendor/geolite/GeoLiteCity.dat}
-set :linked_dirs, %w{bin db/sphinx log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/legacy}
+set :linked_dirs, %w{db/sphinx log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/legacy}
 
 set :keep_releases, 5
 


### PR DESCRIPTION
Out "bins" are part of the app (that's why they are committed to version
control), so they should be redeployed normally.

This should fix the following error in production / staging consoles

```
$ bin/rails c staging
/var/www/beta.nolotiro.org/shared/Gemfile not found
```