### PR TITLE
[devise] `reset_password!` is deprecated

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,7 +107,7 @@ class User < ActiveRecord::Base
   end
 
 
-  def reset_password!(*args)
+  def reset_password(*args)
     self.legacy_password_hash = nil
     super
   end


### PR DESCRIPTION
Esto arregla la migración de legacy passwords a la nueva versión. Pasa desde que usamos una versión de devise con `reset_password!` deprecado (esperemos que no hayan sido muchos casos... :S).