### PR TITLE
Split user tabs into want and give

### DIFF
--- a/app/assets/stylesheets/common.sass.erb
+++ b/app/assets/stylesheets/common.sass.erb
@@ -817,11 +817,8 @@ ul#tabnav
       /* set additional spacing between tabs as desired
       text-decoration: none
       border-bottom: none
-  a:hover
+  a:hover, .active
     color: #000 !important
-
-a#tab_active
-  color: #000 !important
 
 /* end css tabs
 
@@ -1136,9 +1133,6 @@ $langs: <%= Rails.application.secrets["langs"] %>
 
   #ad_body, textarea
     width: 95% !important
-
-  #list-ads-profile .info
-    display: inline-block
 
 @media only screen and (min-width: 780px)
   .span-6.desktop

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -59,6 +59,8 @@ class ApplicationController < ActionController::Base
     params[:type] == 'want' ? params[:type] : 'give'
   end
 
+  helper_method :type_scope
+
   private
 
   def get_location_suggest 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,6 +55,10 @@ class ApplicationController < ActionController::Base
 
   helper_method :status_scope
 
+  def type_scope
+    params[:type] == 'want' ? params[:type] : 'give'
+  end
+
   private
 
   def get_location_suggest 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,14 +47,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def status_scope
-    return 'available' unless %w(booked delivered).include?(params[:status])
-
-    params[:status]
-  end
-
-  helper_method :status_scope
-
   def type_scope
     params[:type] == 'want' ? params[:type] : 'give'
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,8 +10,9 @@ class UsersController < ApplicationController
     @ads = @user.ads
                 .includes(:user)
                 .public_send(@type)
-                .public_send(@status)
                 .paginate(:page => params[:page])
+
+    @ads = @ads.public_send(@status) if @status
   end
 
   # GET '/profile/:username'
@@ -24,4 +25,13 @@ class UsersController < ApplicationController
     end
   end
 
+  private
+
+  def status_scope
+    return unless %w(available booked delivered).include?(params[:status])
+
+    params[:status]
+  end
+
+  helper_method :status_scope
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,9 +4,13 @@ class UsersController < ApplicationController
   def listads
     # ads lists for user
     @user = User.find(params[:id])
+    @type = type_scope
+    @status = status_scope
+
     @ads = @user.ads
                 .includes(:user)
-                .public_send(status_scope)
+                .public_send(@type)
+                .public_send(@status)
                 .paginate(:page => params[:page])
   end
 

--- a/app/controllers/woeid_controller.rb
+++ b/app/controllers/woeid_controller.rb
@@ -30,10 +30,4 @@ class WoeidController < ApplicationController
       end
     end
   end
-
-  private
-
-  def type_scope
-    params[:type] == 'want' ? params[:type] : 'give'
-  end
 end

--- a/app/controllers/woeid_controller.rb
+++ b/app/controllers/woeid_controller.rb
@@ -30,4 +30,14 @@ class WoeidController < ApplicationController
       end
     end
   end
+
+  private
+
+  def status_scope
+    return 'available' unless %w(booked delivered).include?(params[:status])
+
+    params[:status]
+  end
+
+  helper_method :status_scope
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,15 @@
 module ApplicationHelper
+  def messages_tab?
+    params[:controller] == 'messages'
+  end
+
+  def profile_tab?
+    params[:controller] == 'users' && params['action'] == 'profile'
+  end
+
+  def ad_tab?
+    params[:controller] == 'users' && params['action'] == 'listads'
+  end
 
   def escape_privacy_data text
     if text

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -3,8 +3,8 @@
 
 #default_header_section
   %h1=title
-#main.row
-  .col-md-10#list-messages-profile
+#main
+  .span-18
     = render partial: "users/tabnav", locals: {user: current_user}
     = render partial: "messages/tabmessages", locals: {box: @box}
     - if @search

--- a/app/views/users/_filter_status.html.erb
+++ b/app/views/users/_filter_status.html.erb
@@ -1,0 +1,13 @@
+<div class="filter_status">
+  <!-- TODO: Once #213 is fixed we can simplify some checks here -->
+
+  <%= link_to t('nlt.available'), url_for(type: 'give', status: 'available'),
+    :class => type_scope == "give" && status_scope == "available" ? "actual" : "''" %>
+  <%= link_to t('nlt.booked'), url_for(type: 'give', status: 'booked'),
+    :class => type_scope == "give" && status_scope == "booked" ? "actual" : "''" %>
+  <%= link_to t('nlt.delivered'), url_for(type: 'give', status: 'delivered'),
+    :class => type_scope == "give" && status_scope == "delivered" ? "actual" : "''" %>
+
+  <%= link_to t('nlt.want'), url_for(type: 'want'),
+    :class => type_scope == "want" ? "actual" : "''" %>
+</div>

--- a/app/views/users/_filter_status.html.erb
+++ b/app/views/users/_filter_status.html.erb
@@ -1,6 +1,9 @@
 <div class="filter_status">
   <!-- TODO: Once #213 is fixed we can simplify some checks here -->
 
+  <%= link_to t('nlt.all'), url_for(type: 'give'),
+    :class => type_scope == "give" && status_scope.nil? ? "actual" : "''" %>
+
   <%= link_to t('nlt.available'), url_for(type: 'give', status: 'available'),
     :class => type_scope == "give" && status_scope == "available" ? "actual" : "''" %>
   <%= link_to t('nlt.booked'), url_for(type: 'give', status: 'booked'),

--- a/app/views/users/_tabnav.html.erb
+++ b/app/views/users/_tabnav.html.erb
@@ -1,15 +1,17 @@
 <ul id="tabnav">
-<!-- TODO: can an user edit or view messages from another user? -->
-<!-- TODO: active class in partials -->
+  <!-- TODO: can an user edit or view messages from another user? -->
+  <!-- TODO: active class in partials -->
   <% if user_signed_in? and user.id == current_user.id %>
     <li>
-    <%= link_to t('nlt.messages'), messages_list_path %>
+      <%= link_to t('nlt.messages'), messages_list_path %>
     </li>
   <% end %>
+
   <li>
     <%= link_to t('nlt.profile'), profile_path(user) %>
   </li>
+
   <li>
-  <%= link_to t('nlt.user_ads'), listads_user_path(user) %>
+    <%= link_to t('nlt.user_ads'), listads_user_path(user) %>
   </li>
 </ul>

--- a/app/views/users/_tabnav.html.erb
+++ b/app/views/users/_tabnav.html.erb
@@ -1,17 +1,22 @@
 <ul id="tabnav">
   <!-- TODO: can an user edit or view messages from another user? -->
-  <!-- TODO: active class in partials -->
   <% if user_signed_in? and user.id == current_user.id %>
     <li>
-      <%= link_to t('nlt.messages'), messages_list_path %>
+      <%= link_to t('nlt.messages'),
+                  messages_list_path,
+                  class: ('active' if messages_tab?) %>
     </li>
   <% end %>
 
   <li>
-    <%= link_to t('nlt.profile'), profile_path(user) %>
+    <%= link_to t('nlt.profile'),
+                profile_path(user),
+                class: ('active' if profile_tab?) %>
   </li>
 
   <li>
-    <%= link_to t('nlt.user_ads'), listads_user_path(user) %>
+    <%= link_to t('nlt.user_ads'),
+                listads_user_path(user),
+                class: ('active' if ad_tab?) %>
   </li>
 </ul>

--- a/app/views/users/_tabnav.html.erb
+++ b/app/views/users/_tabnav.html.erb
@@ -3,15 +3,13 @@
 <!-- TODO: active class in partials -->
   <% if user_signed_in? and user.id == current_user.id %>
     <li>
-    <%= link_to_unless_current t('nlt.messages'), messages_list_path %>
+    <%= link_to t('nlt.messages'), messages_list_path %>
     </li>
   <% end %>
   <li>
-    <%= link_to_unless request.fullpath =~ /\/profile\//,
-                       t('nlt.profile'),
-                       profile_path(user) %>
+    <%= link_to t('nlt.profile'), profile_path(user) %>
   </li>
   <li>
-  <%= link_to_unless_current t('nlt.user_ads'), listads_user_path(user) %>
+  <%= link_to t('nlt.user_ads'), listads_user_path(user) %>
   </li>
 </ul>

--- a/app/views/users/listads.html.erb
+++ b/app/views/users/listads.html.erb
@@ -10,7 +10,7 @@
 
     <%= render partial: "users/tabnav", locals: {user: @user} %>
 
-    <%= render "woeid/filter_status" %>
+    <%= render "filter_status" %>
 
     <div class="span-5 mobile">
       <div class="google_ad_wrapper">

--- a/app/views/users/listads.html.erb
+++ b/app/views/users/listads.html.erb
@@ -6,7 +6,7 @@
 
 <div id="main">
 
-  <div class="span-17" id="list-ads-profile">
+  <div class="span-18">
 
     <%= render partial: "users/tabnav", locals: {user: @user} %>
 

--- a/test/integration/personal_ad_listing_test.rb
+++ b/test/integration/personal_ad_listing_test.rb
@@ -13,22 +13,32 @@ class PersonalAdListing < ActionDispatch::IntegrationTest
     create(:ad, user: @user, title: 'ava2', status: 1, published_at: 1.day.ago)
     create(:ad, user: @user, title: 'res1', status: 2)
     create(:ad, user: @user, title: 'del1', status: 3)
+    create(:ad, user: @user, title: 'wan1', type: 2)
 
     create(:ad, title: "something else to ensure it's filtered out")
 
-    with_pagination(1) do
-      login(@user.email, @user.password)
-      within('.user_login_box') { click_link @user.username }
-      click_link 'anuncios'
-    end
+    login(@user.email, @user.password)
+    within('.user_login_box') { click_link @user.username }
+    click_link 'anuncios'
+  end
+
+  it 'lists wanted ads in a separate tab in user profile' do
+    click_link 'busco'
+
+    page.assert_selector '.ad_excerpt_home', count: 1, text: 'wan1'
   end
 
   it 'lists first page of user available ads in user profile' do
+    with_pagination(1) { click_link 'disponible' }
+
     page.assert_selector '.ad_excerpt_home', count: 1, text: 'ava1'
   end
 
-  it 'lists other pages of user ads in user profile' do
-    with_pagination(1) { click_link 'siguiente' }
+  it 'lists other pages of user available ads in user profile' do
+    with_pagination(1) do
+      click_link 'disponible'
+      click_link 'siguiente'
+    end
 
     page.assert_selector '.ad_excerpt_home', count: 1, text: 'ava2'
   end

--- a/test/integration/personal_ad_listing_test.rb
+++ b/test/integration/personal_ad_listing_test.rb
@@ -22,6 +22,12 @@ class PersonalAdListing < ActionDispatch::IntegrationTest
     click_link 'anuncios'
   end
 
+  it 'lists all give ads in a separate tab in user profile' do
+    click_link 'todos'
+
+    page.assert_selector '.ad_excerpt_home', count: 4
+  end
+
   it 'lists wanted ads in a separate tab in user profile' do
     click_link 'busco'
 


### PR DESCRIPTION
Esta PR hace dos cosas:

- Soluciona el bug por el que los regalos de busco aparecen bajo el filtro de regalos "disponibles".
- Mejora la apariencia y consistencia de los tabs, a ver qué os parece.

Antes:

![captura de pantalla de 2016-04-15 11 04 25](https://cloud.githubusercontent.com/assets/2887858/14556710/d53c6ed2-02f9-11e6-9d63-71430a38337f.png)

Después:

![captura de pantalla de 2016-04-15 11 04 22](https://cloud.githubusercontent.com/assets/2887858/14556718/dd054e0e-02f9-11e6-9ee5-6379b5d03ee5.png)

