### PR TITLE
[ads] Improve location counts performance

### DIFF
--- a/app/helpers/ad_helper.rb
+++ b/app/helpers/ad_helper.rb
@@ -2,7 +2,9 @@
 module AdHelper
 
   def self.get_locations_ranking(limit=20)
-    Ad.give.group_by(&:woeid_code).map{ |w,a| [WoeidHelper.convert_woeid_name(w)[:full], w, a.count] }.sort_by{|k| k[2]}.reverse.take(limit) 
+    Ad.unscoped.give.group(:woeid_code).order('count_id desc').limit(limit).count('id').map do |w, c|
+      [WoeidHelper.convert_woeid_name(w)[:full], w, c]
+    end
   end
 
 end


### PR DESCRIPTION
Several performance improvements here:
* Filter first, then resolver woeid names only of filtered items.
* Sort by SQL.
* Group by SQL.
* Count by SQL.

No he añadido test porque me daba pereza, pero lo he corrido sobre la db de producción cargada en local y da los mismos resultados con la cache vacía (salvo algunas resoluciones de empates que ordena diferente), sólo que tarda como 6 veces menos.