### PR TITLE
[data] Add a task to migrate duplicate users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ gem 'active_skin'                                   # admin backend skin
 gem 'rakismet'                                      # antispam
 gem 'font-awesome-rails'                            # font-awesome icons
 gem 'faker'
+gem 'ruby-progressbar'
 
 gem 'mailboxer', '0.13.0'                           # messaging
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -360,6 +360,7 @@ GEM
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     riddle (1.5.12)
+    ruby-progressbar (1.7.5)
     ruby_parser (3.7.2)
       sexp_processor (~> 4.1)
     sass (3.4.22)
@@ -492,6 +493,7 @@ DEPENDENCIES
   rb-readline (~> 0.5.0)
   recaptcha
   redis-rails
+  ruby-progressbar
   sass-rails (~> 5.0)
   sdoc
   sidekiq

--- a/app/migrators/concerns/duplicate_user_chooser.rb
+++ b/app/migrators/concerns/duplicate_user_chooser.rb
@@ -1,0 +1,40 @@
+#
+# Chooses the user that will stay in DB from a series of users
+#
+class DuplicateUserChooser
+  def initialize(users)
+    @users = users
+  end
+
+  def choose
+    user = latest_sign_in ||
+           latest_published_ad ||
+           latest_confirmation ||
+           latest_confirmation_sent
+    abort unless user
+
+    user.id
+  end
+
+  private
+
+  def latest_sign_in
+    latest_by(:current_sign_in_at) || latest_by(:last_sign_in_at)
+  end
+
+  def latest_published_ad
+    @users.joins(:ads).order('ads.published_at').last
+  end
+
+  def latest_confirmation
+    latest_by(:confirmed_at)
+  end
+
+  def latest_confirmation_sent
+    latest_by(:confirmation_sent_at)
+  end
+
+  def latest_by(column)
+    @users.where.not(column => nil).order(column => :asc).last
+  end
+end

--- a/app/migrators/concerns/duplicate_user_finders.rb
+++ b/app/migrators/concerns/duplicate_user_finders.rb
@@ -1,0 +1,12 @@
+#
+# Some scopes for finding duplications in the users table
+#
+module DuplicateUserFinders
+  def duplicated_emails
+    group('lower(email)').having('count(*) > 1').pluck('lower(email)')
+  end
+
+  def duplicates_for(email)
+    where("lower(email) = '#{email}'")
+  end
+end

--- a/app/migrators/duplicate_user_migrator.rb
+++ b/app/migrators/duplicate_user_migrator.rb
@@ -1,0 +1,65 @@
+require 'ruby-progressbar'
+require 'concerns/duplicate_user_chooser'
+require 'concerns/duplicate_user_finders'
+
+#
+# Migrates duplicated references to a user
+#
+class DuplicateUserMigrator
+  def initialize(email)
+    @email = email
+  end
+
+  def self.migrate!
+    User.extend(DuplicateUserFinders)
+
+    duplicated_emails = User.duplicated_emails
+
+    bar = ProgressBar.create(total: duplicated_emails.size,
+                             format: '%a %B %c/%C')
+
+    duplicated_emails.each do |email|
+      new(email).migrate!
+
+      bar.increment
+    end
+  end
+
+  def migrate!
+    update_references
+
+    User.where(id: duplicate_ids).destroy_all
+
+    User.find(chosen_id).update(email: @email.downcase)
+  end
+
+  private
+
+  def users
+    @users ||= User.duplicates_for(@email)
+  end
+
+  def chosen_id
+    @chosen_id ||= DuplicateUserChooser.new(users).choose
+  end
+
+  def duplicate_ids
+    @duplicate_ids ||= users.where.not(id: chosen_id).pluck(:id)
+  end
+
+  def update_references
+    update_reference(Ad, :user_owner)
+    update_reference(Comment, :user_owner)
+    update_reference(Friendship, :user_id)
+    update_reference(Friendship, :friend_id)
+    update_reference(Legacy::Message, :user_from)
+    update_reference(Legacy::Message, :user_to)
+    update_reference(Legacy::MessageThread, :last_speaker)
+    update_reference(Mailboxer::Receipt, :receiver_id)
+    update_reference(Mailboxer::Message, :sender_id)
+  end
+
+  def update_reference(model, column)
+    model.where(column => duplicate_ids).update_all(column => chosen_id)
+  end
+end

--- a/lib/tasks/nolotiro/merge_duplicate_users.rake
+++ b/lib/tasks/nolotiro/merge_duplicate_users.rake
@@ -1,0 +1,10 @@
+namespace :nolotiro do
+  namespace :merge do
+    desc '[nolotiro] Merge users with different case variations of same email'
+    task duplicate_users: :environment do
+      require 'duplicate_user_migrator'
+
+      DuplicateUserMigrator.migrate!
+    end
+  end
+end


### PR DESCRIPTION
There are 1111 duplicated users in database. This is because we used to
allow insertion of mixed-case emails in database. So now if
"EMAIL@example.com" is already in database, insertion of a user with
email "email@example.com" won't fail, because what `devise` checks is
that the downcased version of the email to be inserted is not already in
database.

For the migration, I use several criteria to choose the preferred user.

In order of precedence:
- Last login time.
- Last published ad.
- Last confirmation.
- Last sent confirmation email.

After that, all data is updated to point to the preferred user and the
duplicated users are deleted.