### PR TITLE
Migrator to remove all invalid woeids in DB

### DIFF
--- a/app/migrators/concerns/woeid_inferer.rb
+++ b/app/migrators/concerns/woeid_inferer.rb
@@ -1,0 +1,29 @@
+require 'concerns/yahoo_location'
+
+#
+# Finds a proper "town" woeid for a user
+#
+# @note: assumes ads all have town woeids
+#
+class WoeidInferer
+  def initialize(user)
+    @user = user
+  end
+
+  def run
+    place.ancestor_town || last_ad_woeid || place.descendant_town || 766_273
+  end
+
+  private
+
+  def last_ad_woeid
+    ads = @user.ads
+    return unless ads.any?
+
+    ads.order(published_at: :asc).last.woeid_code
+  end
+
+  def place
+    @place ||= YahooLocation.new(@user.woeid)
+  end
+end

--- a/app/migrators/concerns/yahoo_location.rb
+++ b/app/migrators/concerns/yahoo_location.rb
@@ -1,0 +1,64 @@
+#
+# Wraper around GeoPlanet::Place to find places related places that are towns
+#
+class YahooLocation
+  attr_accessor :woeid
+
+  def initialize(woeid)
+    @woeid = woeid
+  end
+
+  def self.all
+    @all ||= User.pluck(:woeid).uniq.map { |w| new(w) }
+  end
+
+  def place
+    GeoPlanet::Place.new(woeid)
+  rescue GeoPlanet::NotFound
+    nil
+  end
+
+  def town?
+    return false unless place
+
+    place.placetype_code == 7
+  end
+
+  def descendants
+    @descendants ||= GeoPlanet::Place.children_of(woeid)
+  end
+
+  def parent
+    @parent ||= GeoPlanet::Place.parent_of(woeid)
+  end
+
+  def parent_town?
+    parent.placetype_code == 7
+  end
+
+  def ancestor_town
+    return unless parent
+
+    return self.class.new(parent.woeid).ancestor_town unless parent_town?
+
+    parent.woeid
+  end
+
+  def descendant_town
+    return unless descendants.present?
+
+    return inmediate_descendant_town if inmediate_descendant_town
+
+    descendants.each do |d|
+      dt = self.class.new(d.woeid).descendant_town
+      return dt if dt
+    end
+  end
+
+  def inmediate_descendant_town
+    descendant = descendants.find { |d| d.placetype_code == 7 }
+    return unless descendant
+
+    descendant.woeid
+  end
+end

--- a/app/migrators/not_town_woeid_migrator.rb
+++ b/app/migrators/not_town_woeid_migrator.rb
@@ -1,0 +1,48 @@
+require 'ruby-progressbar'
+require 'concerns/yahoo_location'
+require 'concerns/woeid_inferer'
+
+#
+# Migrates woeids in users table to be all of "town" type.
+#
+class NotTownWoeidMigrator
+  def initialize
+    GeoPlanet.appid = Rails.application.secrets['geoplanet_app_id']
+  end
+
+  def migrate!
+    bar = ProgressBar.create(title: 'Migrating invalid woeids...',
+                             total: users.count,
+                             format: '%t %a %B %c/%C')
+
+    users.each do |user|
+      user.update!(woeid: WoeidInferer.new(user).run)
+
+      bar.increment
+    end
+  end
+
+  private
+
+  def users
+    @users ||= User.where.not(woeid: invalid_locations.map(&:woeid))
+  end
+
+  def locations
+    @locations ||= YahooLocation.all
+  end
+
+  def invalid_locations
+    bar = ProgressBar.create(title: 'Detecting invalid woeids...',
+                             total: locations.size,
+                             format: '%t %a %B %c/%C')
+
+    locations.select do |location|
+      status = location.town?
+
+      bar.increment
+
+      status
+    end
+  end
+end

--- a/lib/tasks/nolotiro/migrate_not_town_woeids.rake
+++ b/lib/tasks/nolotiro/migrate_not_town_woeids.rake
@@ -1,0 +1,10 @@
+namespace :nolotiro do
+  namespace :migrate do
+    desc '[nolotiro] Migrates user woeids that are not towns'
+    task not_town_woeids: :environment do
+      require 'not_town_woeid_migrator'
+
+      NotTownWoeidMigrator.new.migrate!
+    end
+  end
+end


### PR DESCRIPTION
We currently have no ads with invalid woeid, but have a lot of users
with those. This commit intends to remove those from the DB in a sane
way. The migration has two phases:

* First, invalid woeids are detecting by querying the Yahoo API for the
type of each woeid and checking that it's a town.

* Then, an alternative "town woeid" is found for every invalid woeid.
Here, the criteria, in order from most to less priority is:
  - If woeid refers to a postal code, district or any other entity of
    lower degree than a town, use the containing town.
  - If the user with the invalid woeid has published ads, use woeid of
    the last published ad.
  - If woeid refers to a region, country or any other entity of higher
    degree than a town, use any contained town.
  - If woeid is invalid, use Madrid.