### PR TITLE
Fix hreflang errors in google webmastertools

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'coffee-rails', '~> 4.0.0'
 gem 'therubyracer', platforms: :ruby
 gem 'jquery-rails'
 gem 'jbuilder', '~> 1.2'
-gem 'rb-readline', '~> 0.5.0', :require => false
 
 group :doc do
   gem 'sdoc', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,6 @@ GEM
       activesupport (>= 3.0)
       i18n
       polyamorous (~> 1.2)
-    rb-readline (0.5.3)
     rdoc (4.2.1)
       json (~> 1.4)
     recaptcha (1.0.2)
@@ -497,7 +496,6 @@ DEPENDENCIES
   rails (~> 4.2)
   rails-footnotes (~> 4.0)
   rakismet
-  rb-readline (~> 0.5.0)
   recaptcha
   redis-rails
   ruby-progressbar

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,17 +29,18 @@ NolotiroOrg::Application.routes.draw do
       get '/:id/:slug', to: 'ads#show', :as => 'adslug'
       get '/edit/id/:id', to: 'ads#edit', :as => 'ads_edit'
       post '/bump/id/:id', to: 'ads#bump', :as => 'ads_bump'
-      get '/listall/ad_type/:type', to: 'woeid#show', as: "ads_listall" 
-      get '/listall/ad_type/:type/status/:status', to: 'woeid#show', as: 'ads_listall_status'
-      get '/listall/page/:page/ad_type/:type', to: redirect('/ad/listall/ad_type/%{type}?page=%{page}')
-      get '/listuser/id/:id', to: 'users#listads', as: 'listads_user'
+      get '/listall/ad_type/:type(/status/:status)(/page/:page)',
+          to: 'woeid#show',
+          as: 'ads_listall'
+      get '/listuser/id/:id(/type/:type)(/status/:status)(/page/:page)',
+          to: 'users#listads',
+          as: 'listads_user'
     end
 
     # locations lists
-    get '/woeid/:id/:type', to: 'woeid#show', as: 'ads_woeid'
-    get '/woeid/:id/:type/page/:page', to: redirect('/woeid/%{id}/%{type}?page=%{page}')
-    get '/woeid/:id/:type/status/:status', to: 'woeid#show', as: 'ads_woeid_status'
-    get '/woeid/:id/:type/page/:page/status/:status', to: redirect('/woeid/%{id}/%{type}/status/%{status}?page=%{page}')
+    get '/woeid/:id/:type(/status/:status)(/page/:page)',
+        to: 'woeid#show',
+        as: 'ads_woeid'
 
     # location change
     scope '/location' do


### PR DESCRIPTION
The problem is that the pages where `page` is specified as a query
string parameter have no "return tag", because the alternative URLs
have no query string params, so they can't point back to the page.

The solution is to always use URLs using "page" as a url segment. Since
in the filters template we use `url_for` and sometimes the current URL
is the user profile, some URLs were still generated the old way, so I
split the filters in user profile to a separate view and used
`listall_ads_path` there.