### PR TITLE
Fix `nolotiro:download_maxmind_db` task

### DIFF
--- a/lib/tasks/nolotiro/download_maxmind_db.rake
+++ b/lib/tasks/nolotiro/download_maxmind_db.rake
@@ -1,6 +1,6 @@
 namespace :nolotiro do
   desc '[nolotiro] Downloads a maxmind binary Geolite2 db'
-  task :download_maxmind_db do
+  task download_maxmind_db: :environment do
     require 'maxmind_downloader'
 
     MaxmindDownloader.new.run!


### PR DESCRIPTION
We need the environment preloaded so that the `downloaders` folder is
added to the `LOAD_PATH`.