### PR TITLE
[geo] Keep all GeoliteCity DBs between deployments

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -14,8 +14,8 @@ set :deploy_via, :remote_cache
 
 set :ssh_options, { :forward_agent => true }
 
-set :linked_files, %w{config/database.yml config/secrets.yml config/newrelic.yml vendor/geolite/GeoLiteCity.dat}
-set :linked_dirs, %w{db/sphinx log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/legacy}
+set :linked_files, %w{config/database.yml config/secrets.yml config/newrelic.yml}
+set :linked_dirs, %w{db/sphinx log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/legacy vendor/geolite}
 
 set :keep_releases, 5
 


### PR DESCRIPTION
Last PR before migrating to Geolite2.

I need to make sure the `vendor/geolite` is left untouched between deployments, and only then download the new GeoliteCity DB file.