### PR TITLE
Make ads fit in the right side of user profile

### DIFF
--- a/app/views/users/listads.html.erb
+++ b/app/views/users/listads.html.erb
@@ -29,7 +29,7 @@
 
   </div>
 
-  <div class="span-5 desktop">
+  <div class="span-4 desktop">
     <div class="google_ad_wrapper">
       <%= render partial: "partials/google_adsense", locals: { class_name: "google_adsense_600_160", ad_slot: "6783776462"}  %>
     </div>


### PR DESCRIPTION
Just a quick dirty fix before we review the whole grid.

Fixes #256.