### PR TITLE
Remove default user woeid

### DIFF
--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -89,7 +89,10 @@ class Ad < ActiveRecord::Base
   self.per_page = 20
 
   def self.cache_digest
-    Ad.maximum(:created_at).strftime("%d%m%y%H%M%s")
+    last_ad_creation = Ad.maximum(:created_at)
+    return '0' * 20 unless last_ad_creation
+
+    last_ad_creation.strftime("%d%m%y%H%M%s")
   end
 
   def body 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -16,33 +16,25 @@
         <%= devise_error_messages! %>
         <dl class="zend_form">
           <dt id="email-label">
-          <label for="email" class="required">
-            <%= t 'nlt.your_email' %>
-          </label>
+            <%= f.label :email, t('nlt.your_email') %>
           </dt>
           <dd id="email-element">
           <%= f.email_field :email, :autofocus => true, :required => true %>
           </dd>
           <dt id="password1-label">
-          <label for="password1" class="required">
-            <%= t 'nlt.choose_your_pass' %>
-          </label>
+            <%= f.label :password, t('nlt.choose_your_pass') %>
           </dt>
           <dd id="password1-element">
           <%= f.password_field :password, :required => true %>
           </dd>
           <dt id="password2-label">
-          <label for="password2" class="required">
-            <%= t 'nlt.choose_your_pass_again' %>
-          </label>
+            <%= f.label :password_confirmation, t('nlt.choose_your_pass_again') %>
           </dt>
           <dd id="password2-element">
           <%= f.password_field :password_confirmation, :required => true %>
           </dd>
           <dt id="username-label">
-          <label for="username" class="required">
-            <%= t 'nlt.choose_username' %>
-          </label>
+            <%= f.label :username, t('nlt.choose_username') %>
           </dt>
           <dd id="username-element">
           <%= f.text_field :username, :required => true, :value => params[:username] %>

--- a/db/migrate/20160603152006_remove_default_woeid.rb
+++ b/db/migrate/20160603152006_remove_default_woeid.rb
@@ -1,0 +1,11 @@
+class RemoveDefaultWoeid < ActiveRecord::Migration
+  def up
+    change_column_null :users, :woeid, true
+    change_column_default :users, :woeid, nil
+  end
+
+  def down
+    change_column_default :users, :woeid, 766_273
+    change_column_null :users, :woeid, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160423085940) do
+ActiveRecord::Schema.define(version: 20160603152006) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace",     limit: 255
@@ -124,20 +124,20 @@ ActiveRecord::Schema.define(version: 20160423085940) do
   add_index "mailboxer_receipts", ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "username",               limit: 32,                   null: false
+    t.string   "username",               limit: 32,               null: false
     t.string   "legacy_password_hash",   limit: 255
-    t.string   "email",                  limit: 100,                  null: false
-    t.date     "created_at",                                          null: false
-    t.integer  "active",                 limit: 4,   default: 0,      null: false
+    t.string   "email",                  limit: 100,              null: false
+    t.date     "created_at",                                      null: false
+    t.integer  "active",                 limit: 4,   default: 0,  null: false
     t.integer  "locked",                 limit: 4
-    t.integer  "role",                   limit: 4,   default: 0,      null: false
-    t.integer  "woeid",                  limit: 4,   default: 766273, null: false
-    t.string   "lang",                   limit: 4,                    null: false
-    t.string   "encrypted_password",     limit: 255, default: "",     null: false
+    t.integer  "role",                   limit: 4,   default: 0,  null: false
+    t.integer  "woeid",                  limit: 4
+    t.string   "lang",                   limit: 4,                null: false
+    t.string   "encrypted_password",     limit: 255, default: "", null: false
     t.string   "reset_password_token",   limit: 255
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          limit: 4,   default: 0,      null: false
+    t.integer  "sign_in_count",          limit: 4,   default: 0,  null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip",     limit: 255

--- a/test/integration/registration_test.rb
+++ b/test/integration/registration_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+require 'integration/concerns/authentication'
+
+class RegistrationTest < ActionDispatch::IntegrationTest
+  include Authentication
+
+  before do
+    visit root_path
+    click_link 'nuevo usuario'
+    fill_in 'Tu email', with: 'nolotiro@example.com'
+    fill_in 'Elige tu contraseña', with: '111111'
+    fill_in 'Introduce tu contraseña', with: '111111'
+    fill_in 'Elige un nombre de usuario', with: 'nolotiro'
+    click_button 'Regístrate'
+  end
+
+  it 'sends a confirmation email' do
+    msg = <<-TEXT
+      Se ha enviado un mensaje con un enlace de confirmación a tu correo
+      electrónico.
+    TEXT
+
+    assert page.has_content?(msg)
+  end
+
+  it 'redirects to change city page after first login' do
+    User.first.confirm
+    login('nolotiro@example.com', '111111')
+
+    assert page.has_content?('Cambia tu ciudad')
+  end
+end


### PR DESCRIPTION
This changes the initial registration flow.

Before,

After registration and logging in for the first time, the user would
_always_ be redirected to the "Madrid, Madrid, Spain" page, and the
green button would _always_ show "Publish ad in Madrid". Users from
outside Madrid had to go click the link "Change city" link in order to
publish in a different city.

Now,

On first login the user is automatically redirected to the "Change city"
page so she can choose her location.

I think this is a better flow and makes the tests run much faster since
new users don't have a default woeid, so no Yahoo API calls are made by
default.

---------------------------------------------

No sé qué os parece y si está clara la explicación. Puedo añadir alguna captura o grabación de pantalla si no lo está.

El hecho de que [el controlador](https://github.com/alabs/nolotiro.org/blob/master/app/controllers/ads_controller.rb#L11) esté ya escrito para este tipo de flujo me hace preguntarme si antes esto funcionaba así. Fijáos que antes de este cambio la rama de `woeid` a `nil` de ese código que enlazo es dead code y nunca se ejecuta...

No sé, qué opináis?

NOTA: Esto tiene el beneficio añadido de que los tests tocan mucho menos la API de Yahoo y van mucho más rápido, pero desde luego no es un motivo para cambiarlo.