### PR TITLE
Yahoo bugs

### DIFF
--- a/app/controllers/ads_controller.rb
+++ b/app/controllers/ads_controller.rb
@@ -19,7 +19,7 @@ class AdsController < ApplicationController
     @ads = Rails.cache.fetch("ads_list_#{params[:page]}") do 
       Ad.give.available.includes(:user).paginate(:page => params[:page])
     end
-    @location = get_location_suggest
+    @location_suggest = get_location_suggest
   end
 
   # GET /ads/1

--- a/app/helpers/geo_helper.rb
+++ b/app/helpers/geo_helper.rb
@@ -2,11 +2,13 @@
 module GeoHelper
 
   def self.get_ip_address request
-    ip_address = Rails.application.secrets["debug_ip_address"].presence || request.remote_ip
-    if request.env['HTTP_X_FORWARDED_FOR']
-      ip_address = request.env['HTTP_X_FORWARDED_FOR'].split(',')[0] || ip_address
-    end
-    ip_address
+    debug_ip_address = Rails.application.secrets["debug_ip_address"]
+    return debug_ip_address if debug_ip_address.present?
+
+    ip_via_proxy = request.env['HTTP_X_FORWARDED_FOR']
+    return ip_via_proxy.split(',')[0] if ip_via_proxy
+
+    request.remote_ip
   end
 
   def self.suggest ip_address

--- a/app/helpers/geo_helper.rb
+++ b/app/helpers/geo_helper.rb
@@ -17,7 +17,7 @@ module GeoHelper
     db = MaxMindDB.new(Rails.root.to_s + '/vendor/geolite/GeoLite2-City.mmdb')
     suggestion = db.lookup(ip_address)
     # FIXME: use other APIs when there isn't an IP address mapped
-    return "Madrid, Madrid, España" unless suggestion.found?
+    return unless suggestion.found?
 
     city = suggestion.city
     city_name = city.name(I18n.locale) || city.name('en')

--- a/app/views/ads/_no_results.html.erb
+++ b/app/views/ads/_no_results.html.erb
@@ -8,18 +8,15 @@
   )%>
   <br>
 
-  <% unless @woeid.nil? %>
-    <% locations = get_location_options @woeid[:short] %>
-    <% if locations %>
-      <%= t('nlt.no_results.try') %><br>
-      <ul>
-      <% locations.each do |l| %>
+  <% if location_options.present? %>
+    <%= t('nlt.no_results.try') %><br>
+    <ul>
+      <% location_options.each do |l| %>
         <li>
           <%= link_to l[0], location_change_path(location: l[0]) %>
         </li>
       <% end %>
-      </ul>
-    <% end %>
+    </ul>
   <% end %>
 
   <h5>

--- a/app/views/ads/index.html.erb
+++ b/app/views/ads/index.html.erb
@@ -30,9 +30,6 @@
         <%= link_to t('nlt.view_ads_on_your_city'), location_ask_path %>
       <% else %>
         <%= link_to t('nlt.view_ads_on', location_suggest: @location_suggest), location_change_path(location: @location_suggest) %>
-        <%= link_to location_change_path(location: location_suggest) do %>
-          <%= t('nlt.view_ads_on', location_suggest: @location_suggest) %></a>
-        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/woeid/show.html.erb
+++ b/app/views/woeid/show.html.erb
@@ -77,7 +77,7 @@
       <% if defined? @no_results_search %>
         <%= render :partial => "ads/no_results_search", :locals => { :location_suggest => @location_suggest, :location_options => @location_options } %>
       <% else %>
-        <%= render :partial => "ads/no_results", :locals => { :location_suggest => @location_suggest, :location_options => @location_options, :woeid => @id } %>
+        <%= render :partial => "ads/no_results", :locals => { :location_suggest => @location_suggest, :location_options => @location_options } %>
       <% end %>
     <% end %>
 

--- a/config/app_config.yml.example
+++ b/config/app_config.yml.example
@@ -7,7 +7,6 @@ defaults: &defaults
   airbrake_host: ''
   airbrake_port: '80'
   devise_secret_key: 'e4babb7746d1e2302f1fd2ab13d6985512c17e24e5b8e21abbf0199b2a43a5c907db3b30ba6e092c2abfef2d9bf305998958ab4f4fe43dc22343b7379984e284'
-  debug_ip_address: '8.8.8.8'
   langs_routes: 'es|en|ca|gl|eu|nl|de|fr|pt|it'
   langs: 'es en ca gl eu nl de fr pt it'
 

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -1,7 +1,6 @@
 defaults: &defaults
   geoplanet_app_id: "ccc2c6d8c5c9233d952dee39e4e4f05266d3ebc47b809498a7b071b500aefccd269423a8967b3d96700d5c1a630d59159b2b8f4d111714a8fb777362e548bc57"
   devise_secret_key: '9118b06e035a8ae32299625b61497b74079d543598a573659eb7b002a98a9d26793cb86787e11ce7d00350da62dcbdc96dc7a76e7e5c2c79f54798d02067fcef'
-  debug_ip_address: '8.8.8.8'
   langs_routes: 'es|en|ca|gl|eu|nl|de|fr|pt|it'
   langs: 'es en ca gl eu nl de fr pt it'
   localeapp_apikey: ''

--- a/test/helpers/geo_helper_test.rb
+++ b/test/helpers/geo_helper_test.rb
@@ -7,7 +7,7 @@ class GeoHelperTest < ActionView::TestCase
     @request.headers["REMOTE_ADDR"] = "87.223.138.147"
     ip = GeoHelper.get_ip_address(@request)
 
-    assert_equal(ip, "87.223.138.147")
+    assert_equal("87.223.138.147", ip)
   end 
 
   test "should suggest location with ip address" do

--- a/test/helpers/geo_helper_test.rb
+++ b/test/helpers/geo_helper_test.rb
@@ -4,8 +4,9 @@ class GeoHelperTest < ActionView::TestCase
   include GeoHelper
 
   test "should get ip address" do
-    ip = "87.223.138.147"
-    @request.headers["REMOTE_ADDR"] = ip
+    @request.headers["REMOTE_ADDR"] = "87.223.138.147"
+    ip = GeoHelper.get_ip_address(@request)
+
     assert_equal(ip, "87.223.138.147")
   end 
 


### PR DESCRIPTION
Ayer (que estaba sin internet) recuperé algunas ramas que tenía a medio cocinar en local. Esta soluciona algunos temas de geolocalización IP que no estaban funcionando.

Actualmente (a diferencia de la anterior versión de nolotiro), el botón verde para usuarias no registradas siempre contiene "Ver anuncios en tu ciudad o pueblo". Antes mostraba directamente un link a la ciudad sugerida por IP (en mi caso, "Ver anuncios en Río de Janeiro") si había alguna sugerencia o "Ver anuncios en tu ciudad o pueblo" en caso contrario.

Aunque en algunos casos la geolocalización IP no sea muy exacta, esto es mejor que lo que ahora tenemos, ya que siempre está el link de "Cambiar ciudad" para omitir la sugerencia e introducir la ciudad manualmente (ahora mismo este link y el de "Ver anuncios en tu ciudad o pueblo" van al mismo sitio).