### PR TITLE
Don't show message & comment links for certain statuses

### DIFF
--- a/app/views/ads/_ad.html.erb
+++ b/app/views/ads/_ad.html.erb
@@ -34,9 +34,6 @@
     <div><p><%= truncate ad.body, length: 200, separator: ' ' %></p></div>
     <div class="ad_meta_info">
       <b><%= link_to t('nlt.send_a_message'), message_new_with_subject_path(user_id: ad.user.id, subject: ad.slug) %></b>
-      <% if ad.comments_enabled? %>
-        <b><%= link_to t('nlt.write_a_comment'), adslug_path(ad,ad.slug) %></b>
-      <% end %>
       <span class="right small">
         &nbsp;&nbsp; <%= t('nlt.readed_count', count: ad.readed_counter) %><%= t('nlt.comments_count', count: ad.comments_count) %>
       </span>

--- a/app/views/ads/_ad.html.erb
+++ b/app/views/ads/_ad.html.erb
@@ -33,7 +33,11 @@
     </span>
     <div><p><%= truncate ad.body, length: 200, separator: ' ' %></p></div>
     <div class="ad_meta_info">
-      <b><%= link_to t('nlt.send_a_message'), message_new_with_subject_path(user_id: ad.user.id, subject: ad.slug) %></b>
+      <% if ad.status_class == 'available' %>
+        <b>
+          <%= link_to t('nlt.send_a_message'), message_new_with_subject_path(user_id: ad.user.id, subject: ad.slug) %>
+        </b>
+      <% end %>
       <span class="right small">
         &nbsp;&nbsp; <%= t('nlt.readed_count', count: ad.readed_counter) %><%= t('nlt.comments_count', count: ad.comments_count) %>
       </span>

--- a/app/views/ads/show.html.erb
+++ b/app/views/ads/show.html.erb
@@ -38,7 +38,7 @@
 
       <%= t('nlt.are_you_interested') %>
       <%= link_to message_new_with_subject_path(user_id: @ad.user.id, subject: @ad.slug), :class => "world_link" do %>
-        <%= t('nlt.send_a_private_message') %>
+        <%= t('nlt.send_a_message') %>
         <%= image_tag "email_send.png", :alt => t('nlt.send_a_message') %>
       <% end %>
 

--- a/app/views/ads/show.html.erb
+++ b/app/views/ads/show.html.erb
@@ -37,19 +37,26 @@
       </div>
 
       <%= t('nlt.are_you_interested') %>
-      <%= link_to message_new_with_subject_path(user_id: @ad.user.id, subject: @ad.slug), :class => "world_link" do %>
-        <%= t('nlt.send_a_message') %>
-        <%= image_tag "email_send.png", :alt => t('nlt.send_a_message') %>
+
+      <% if @ad.status_class == 'available' %>
+        <%= link_to message_new_with_subject_path(user_id: @ad.user.id, subject: @ad.slug),
+                    :class => "world_link" do %>
+          <%= t('nlt.send_a_message') %>
+          <%= image_tag "email_send.png", :alt => t('nlt.send_a_message') %>
+        <% end %>
       <% end %>
 
       <br><br>
+
       <div class="sharelinks">
         <p style="text-align:left;margin-bottom:5px;"><%= t('nlt.share_this_ad') %>:</p>
         <%= render :partial => "partials/social_buttons", :locals => { :url => ad_url(@ad) } %>
       </div>
     </div>
-    <%= render :partial => "comments/show", :locals => {:ad => @ad} %>
 
+    <% if @ad.comments_enabled? && @ad.status_class != 'delivered' %>
+      <%= render :partial => "comments/show", :locals => {:ad => @ad} %>
+    <% end %>
   </div>
   <div class="span-10">
       <%= render partial: "partials/google_adsense", locals: { class_name: "desktop google_adsense_336_280", ad_slot: "7225596067"}  %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -431,7 +431,6 @@ ca:
     send: Enviar
     send_a_message: "+ Envia un missatge privat a l'anunciant"
     send_a_message_to: envia un missatge privat a
-    send_a_private_message: 
     sending_this_form: Enviant aquest formulari, admeten haver llegit, comprès, i estàs d'acord amb les nostres
     share_this_ad: Comparteix aquest anunci
     sign_in: Accedir

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -431,7 +431,6 @@ de:
     send: 
     send_a_message: 
     send_a_message_to: 
-    send_a_private_message: 
     sending_this_form: 
     share_this_ad: 
     sign_in: 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -431,7 +431,6 @@ en:
     send: Send
     send_a_message: "+ Send a private message to this user"
     send_a_message_to: send a private message to
-    send_a_private_message: 
     sending_this_form: By submitting this form, you admit to having read, understood, and you agree with our
     share_this_ad: Share this ad
     sign_in: Sign in

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -435,7 +435,6 @@ es:
     send: Enviar
     send_a_message: "+ Envía un mensaje privado al anunciante"
     send_a_message_to: 'envía un mensaje privado a '
-    send_a_private_message: "+ Envía un mensaje privado al anunciante"
     sending_this_form: Enviando este formulario, admites haber leido, comprendido, y estás conforme con nuestras
     share_this_ad: Comparte este anuncio
     sign_in: Acceder

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -431,7 +431,6 @@ eu:
     send: 
     send_a_message: 
     send_a_message_to: 
-    send_a_private_message: 
     sending_this_form: 
     share_this_ad: 
     sign_in: 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -433,7 +433,6 @@ fr:
     send: 
     send_a_message: 
     send_a_message_to: 
-    send_a_private_message: 
     sending_this_form: 
     share_this_ad: 
     sign_in: 

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -448,7 +448,6 @@ gl:
     send: 
     send_a_message: 
     send_a_message_to: 
-    send_a_private_message: 
     sending_this_form: Ao enviar este formulario, vostede acepta que leu, entendeu e está feliz co noso
     share_this_ad: Comparte este anuncio
     sign_in: Acceder

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -435,9 +435,8 @@ it:
       no_ads_message_html: 
     searching_on_html: Cercando <i>%{q}</i> in
     send: Inviare
-    send_a_message: "+ Invia un messaggio privato a inserzionista"
+    send_a_message: "+ Invia un messaggio privato al annunciante"
     send_a_message_to: 'envia un messaggio privato a '
-    send_a_private_message: "+ Invia un messaggio privato al annunciante"
     sending_this_form: Inviando questo modulo, ammette di aver letto, compreso, e si è soddisfatti con il nostro
     share_this_ad: Condividi questo annuncio
     sign_in: Login

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -421,7 +421,6 @@ nl:
     send: 
     send_a_message: 
     send_a_message_to: 
-    send_a_private_message: 
     sending_this_form: 
     share_this_ad: 
     sign_in: 

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -431,7 +431,6 @@ pt:
     send: 
     send_a_message: 
     send_a_message_to: 
-    send_a_private_message: 
     sending_this_form: 
     share_this_ad: 
     sign_in: 

--- a/test/integration/links_for_available_ads_test.rb
+++ b/test/integration/links_for_available_ads_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class LinksForAvailableAdsTest < ActionDispatch::IntegrationTest
+  before { @ad = FactoryGirl.create(:ad, status: 1, comments_enabled: true) }
+
+  it 'shows message link in listings' do
+    visit ads_woeid_path(id: 766_273, type: 'give', status: 'available')
+
+    assert page.has_content?('Envía un mensaje privado al anunciante')
+  end
+
+  it 'shows message link in ads' do
+    visit ad_path(@ad)
+
+    assert page.has_content?('Envía un mensaje privado al anunciante')
+  end
+
+  it 'shows comment form in ads' do
+    visit ad_path(@ad)
+
+    assert page.has_content?('accede para escribir un comentario')
+  end
+end

--- a/test/integration/links_for_booked_ads_test.rb
+++ b/test/integration/links_for_booked_ads_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class LinksForBookedAdsTest < ActionDispatch::IntegrationTest
+  before { @ad = FactoryGirl.create(:ad, status: 2, comments_enabled: true) }
+
+  it 'does not show message link in listings' do
+    visit ads_woeid_path(id: 766_273, type: 'give', status: 'booked')
+
+    refute page.has_content?('Envía un mensaje privado al anunciante')
+  end
+
+  it 'does not show message link in ads' do
+    visit ad_path(@ad)
+
+    refute page.has_content?('Envía un mensaje privado al anunciante')
+  end
+
+  it 'shows comment form in ads' do
+    visit ad_path(@ad)
+
+    assert page.has_content?('accede para escribir un comentario')
+  end
+end

--- a/test/integration/links_for_delivered_ads_test.rb
+++ b/test/integration/links_for_delivered_ads_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class LinksForDeliveredAds < ActionDispatch::IntegrationTest
+  before { @ad = FactoryGirl.create(:ad, status: 3, comments_enabled: true) }
+
+  it 'does not show message link in listings' do
+    visit ads_woeid_path(id: 766_273, type: 'give', status: 'delivered')
+
+    refute page.has_content?('Envía un mensaje privado al anunciante')
+  end
+
+  it 'does not show message link in ads' do
+    visit ad_path(@ad)
+
+    refute page.has_content?('Envía un mensaje privado al anunciante')
+  end
+
+  it 'does not show comment link in ads' do
+    visit ad_path(@ad)
+
+    refute page.has_content?('accede para escribir un comentario')
+  end
+end


### PR DESCRIPTION
Fixes #171 

Hay una modificación sobre lo que se discute en #171. Los links de "+ Escribe un comentario" los he quitado para todos los tipos, ya que simplemente estaban enlazando al anuncio, lo cual era un poco confuso.

De hecho creo que deberíamos eliminar también los links de "+ Envía un mensaje privado al anunciante" del listado. Si alguien quiere solicitar algo, que al menos tenga que entrar al anuncio y leerlo/verlo entero...

/cc @andreslucena @iokese 