### PR TITLE
Fix i18n regression

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ gem 'geoplanet'                                     # yahoo woeid geoplanet
 gem 'maxminddb'                                     # geolite city v2
 gem 'will_paginate', '~> 3.0'                       # pagination
 gem 'devise'                                        # users
+gem 'devise-i18n'                                   # devise translations
 gem 'omniauth'                                      # users login with providers
 gem 'omniauth-facebook'                             # users login with facebook
 gem 'omniauth-google-oauth2'                        # users login with google

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,7 @@ GEM
       responders
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
+    devise-i18n (1.0.1)
     domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
@@ -472,6 +473,7 @@ DEPENDENCIES
   database_cleaner (~> 1.5)
   delayed_paperclip
   devise
+  devise-i18n
   factory_girl_rails (~> 4.0)
   faker
   font-awesome-rails

--- a/test/integration/can_access_admin_test.rb
+++ b/test/integration/can_access_admin_test.rb
@@ -6,8 +6,7 @@ class CanAccessAdmin < ActionDispatch::IntegrationTest
 
   it "should not get /admin/jobs as a anonymous user" do
     visit "/admin/jobs"
-    assert \
-      page.has_content?("Para publicar anuncios o enviar mensajes accede a tu cuenta")
+    assert_content "Para publicar anuncios o enviar mensajes accede a tu cuenta"
   end
 
   it "should not get /admin/jobs as a normal user" do
@@ -18,26 +17,26 @@ class CanAccessAdmin < ActionDispatch::IntegrationTest
   it "should get /admin/jobs as admin" do
     login_as admin
     visit "/admin/jobs"
-    assert page.has_content?("Sidekiq")
-    assert page.has_content?("Redis")
-    assert page.has_content?("Memory Usage")
+    assert_content "Sidekiq"
+    assert_content "Redis"
+    assert_content "Memory Usage"
   end
 
   it "should not get /admin as a anonymous user" do
     visit "/admin"
-    assert page.has_content?(I18n.t('devise.failure.unauthenticated'))
+    assert_content I18n.t('devise.failure.unauthenticated')
   end
 
   it "should not get /admin as a normal user" do
     login_as user
     visit "/admin"
-    assert page.has_content?(I18n.t('nlt.permission_denied'))
+    assert_content I18n.t('nlt.permission_denied')
   end
 
   it "should get /admin as admin" do
     login_as admin
     visit "/admin"
-    assert page.has_content?("Últimos anuncios publicados")
+    assert_content "Últimos anuncios publicados"
   end
 
   private

--- a/test/integration/can_user_message_test.rb
+++ b/test/integration/can_user_message_test.rb
@@ -16,23 +16,23 @@ class CanUserMessage < ActionDispatch::IntegrationTest
   it "should message another user" do
     send_message("hola trololo", "hola mundo")
 
-    assert page.has_content?("hola trololo")
-    assert page.has_content?("Mover mensaje a papelera")
+    assert_content("hola trololo")
+    assert_content("Mover mensaje a papelera")
   end
 
   it "should message another user using emojis" do
     skip "emojis not supported"
     send_message("What a nice emoji😀!", "hola mundo")
 
-    assert page.has_content?("What a nice emoji😀!")
-    assert page.has_content?("Mover mensaje a papelera")
+    assert_content("What a nice emoji😀!")
+    assert_content("Mover mensaje a papelera")
   end
 
   it "should reply to a message" do
     send_message("hola trololo", "hola mundo")
     send_message("hola trululu")
 
-    assert page.has_content?("hola trululu")
+    assert_content("hola trululu")
   end
 
   def send_message(body, subject = nil)

--- a/test/integration/facebook_emailless_registration_test.rb
+++ b/test/integration/facebook_emailless_registration_test.rb
@@ -17,13 +17,13 @@ class FacebookEmaillessRegistrationTest < ActionDispatch::IntegrationTest
       cuenta de Facebook o regístrate con tu email
     EOM
 
-    assert page.has_content?(message)
+    assert_content(message)
   end
 
   it 'redirects to email registration form' do
     content = 'Por favor, rellena este formulario para ser miembro de nolotiro'
 
-    assert page.has_content?(content)
+    assert_content(content)
   end
 
   it "autofills form with user's Facebook name" do

--- a/test/integration/unsuccessful_registration_test.rb
+++ b/test/integration/unsuccessful_registration_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+require 'integration/concerns/authentication'
+
+class UnsuccessfulRegistrationTest < ActionDispatch::IntegrationTest
+  include Authentication
+
+  before do
+    visit root_path
+    click_link 'nuevo usuario'
+    click_button 'Regístrate'
+  end
+
+  it 'shows errors' do
+    assert_content 'Ocurrieron 3 errores'
+  end
+end

--- a/test/integration/user_lockable_test.rb
+++ b/test/integration/user_lockable_test.rb
@@ -9,13 +9,13 @@ class UserLockable < ActionDispatch::IntegrationTest
 
     (1..8).each do |n|
       login(@user.email, "trololololo")
-      assert page.has_content?(I18n.t('devise.failure.not_found_in_database'))
+      assert_content(I18n.t('devise.failure.not_found_in_database'))
     end
 
     login(@user.email, "trololololo")
-    assert page.has_content?(I18n.t('devise.failure.last_attempt'))
+    assert_content(I18n.t('devise.failure.last_attempt'))
 
     login(@user.email, "trololololo")
-    assert page.has_content?(I18n.t('devise.failure.locked'))
+    assert_content(I18n.t('devise.failure.locked'))
   end
 end

--- a/test/support/integration.rb
+++ b/test/support/integration.rb
@@ -10,6 +10,11 @@ module ActionDispatch
       Capybara.reset_sessions!
       Rails.cache.clear
     end
+
+    def assert_content(text)
+      msg = "Content '#{text}' was not found in page's content: '#{page.text}'"
+      assert page.has_content?(text), msg
+    end
   end
 
   class Routing::RouteSet


### PR DESCRIPTION
Vuelve a añadir algunas traducciones eliminadas por error (contenidas en la gema `devise-i18n`).