### PR TITLE
Fix nil body reply messages

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -40,12 +40,13 @@ class MessagesController < ApplicationController
       end
       receipt = current_user.reply_to_conversation(@conversation, @message.body, nil, true, true, @message.attachment)
     else
-      @recipient = User.find(recipient_id)
+      recipient = User.find(recipient_id)
       unless @message.valid?
+        @recipient = recipient
         @message.recipients = @recipient.id
         return render :new
       end
-      receipt = current_user.send_message([@recipient], @message.body, @message.subject, true, @message.attachment)
+      receipt = current_user.send_message([recipient], @message.body, @message.subject, true, @message.attachment)
     end
     flash.now[:notice] = I18n.t "mailboxer.notifications.sent" 
     redirect_to mailboxer_message_path(receipt.conversation)

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -27,8 +27,8 @@ class MessagesController < ApplicationController
     @message = Mailboxer::Message.new message_params
     @message.sender = current_user
     # FIXME: this should be on model (validation)
-    if @message.sender.id == params[:mailboxer_message][:recipients].to_i
-      return redirect_to message_create_url(user_id: params[:mailboxer_message][:recipients].to_i), notice: I18n.t("mailboxer.notifications.error_same_user")
+    if @message.sender.id == recipient_id
+      return redirect_to message_create_url(user_id: recipient_id), notice: I18n.t("mailboxer.notifications.error_same_user")
     end
     if @message.conversation_id
       @conversation = Mailboxer::Conversation.find(@message.conversation_id)
@@ -40,7 +40,7 @@ class MessagesController < ApplicationController
       end
       receipt = current_user.reply_to_conversation(@conversation, @message.body, nil, true, true, @message.attachment)
     else
-      @recipient = User.find(params[:mailboxer_message][:recipients])
+      @recipient = User.find(recipient_id)
       unless @message.valid?
         @message.recipients = @recipient.id
         return render :new
@@ -107,4 +107,7 @@ class MessagesController < ApplicationController
     params.require(:mailboxer_message).permit(:conversation_id, :body, :subject, :recipients, :sender_id)
   end
 
+  def recipient_id
+    params[:mailboxer_message][:recipients].to_i
+  end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -41,11 +41,8 @@ class MessagesController < ApplicationController
       receipt = current_user.reply_to_conversation(@conversation, @message.body, nil, true, true, @message.attachment)
     else
       recipient = User.find(recipient_id)
-      unless @message.valid?
-        @recipient = recipient
-        @message.recipients = @recipient.id
-        return render :new
-      end
+      return render_invalid_for(recipient) unless @message.valid?
+
       receipt = current_user.send_message([recipient], @message.body, @message.subject, true, @message.attachment)
     end
     flash.now[:notice] = I18n.t "mailboxer.notifications.sent" 
@@ -110,5 +107,11 @@ class MessagesController < ApplicationController
 
   def recipient_id
     params[:mailboxer_message][:recipients].to_i
+  end
+
+  def render_invalid_for(recipient)
+    @recipient = recipient
+    @message.recipients = @recipient.id
+    render :new
   end
 end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -21,6 +21,7 @@ ca:
         message: 
       mailboxer/message:
         subject: Assumpte
+        body: Missatge
       user:
         Contraseña: Contrasenya
         Recuérdame: Recorda'm

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -21,6 +21,7 @@ de:
         message: 
       mailboxer/message:
         subject: 
+        body: 
       user:
         Contraseña: 
         Recuérdame: 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,7 @@ en:
         message: 
       mailboxer/message:
         subject: Subject
+        body: Message
       user:
         Contraseña: Password
         Recuérdame: Remember me

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -21,6 +21,7 @@ es:
         message: Mensaje
       mailboxer/message:
         subject: Título
+        body: Mensaje
       user:
         Contraseña: Contraseña
         Recuérdame: Recuérdame

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -21,6 +21,7 @@ eu:
         message: 
       mailboxer/message:
         subject: 
+        body: 
       user:
         Contraseña: 
         Recuérdame: 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -21,6 +21,7 @@ fr:
         message: 
       mailboxer/message:
         subject: 
+        body: 
       user:
         Contraseña: 
         Recuérdame: 

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -21,6 +21,7 @@ gl:
         message: Mensaxe
       mailboxer/message:
         subject: Asunto
+        body: Mensaxe
       user:
         Contraseña: Contrasinal
         Recuérdame: Lémbrame

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -21,6 +21,7 @@ it:
         message: Messaggio
       mailboxer/message:
         subject: Soggetto
+        body: Messaggio
       user:
         Contraseña: Password
         Recuérdame: Ricordami

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -21,6 +21,7 @@ nl:
         message: 
       mailboxer/message:
         subject: 
+        body: 
       user:
         Contraseña: 
         Recuérdame: 

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -21,6 +21,7 @@ pt:
         message: 
       mailboxer/message:
         subject: 
+        body: 
       user:
         Contraseña: 
         Recuérdame: 

--- a/test/integration/messages_test.rb
+++ b/test/integration/messages_test.rb
@@ -19,6 +19,12 @@ class MessagesTest < ActionDispatch::IntegrationTest
     assert_content('Título no puede estar en blanco')
   end
 
+  it 'shows errors when message has no body' do
+    send_message(subject: 'hola, user2')
+
+    assert_content('Mensaje no puede estar en blanco')
+  end
+
   it 'sends message after a previous error' do
     send_message(body: 'hola, user2')
     send_message(body: 'hola, user2', subject: 'forgot the title')

--- a/test/integration/messages_test.rb
+++ b/test/integration/messages_test.rb
@@ -14,20 +14,20 @@ class MessagesTest < ActionDispatch::IntegrationTest
   end
 
   it 'shows errors when message has no subject' do
-    send_message('hola, user2')
+    send_message(body: 'hola, user2')
 
     assert_content('Título no puede estar en blanco')
   end
 
   it 'sends message after a previous error' do
-    send_message('hola, user2')
-    send_message('hola, user2', 'forgot the title')
+    send_message(body: 'hola, user2')
+    send_message(body: 'hola, user2', subject: 'forgot the title')
 
     assert_content('Conversación con user2 asunto forgot the title')
   end
 
   it 'shows the other user in the conversation header' do
-    send_message('hola, user2', 'Cosas')
+    send_message(body: 'hola, user2', subject: 'Cosas')
     assert_content('Conversación con user2')
 
     login_as @user2
@@ -37,7 +37,7 @@ class MessagesTest < ActionDispatch::IntegrationTest
   end
 
   it "messages another user" do
-    send_message("hola trololo", "hola mundo")
+    send_message(body: "hola trololo", subject: "hola mundo")
 
     assert_content("hola trololo")
     assert_content("Mover mensaje a papelera")
@@ -45,24 +45,26 @@ class MessagesTest < ActionDispatch::IntegrationTest
 
   it "messages another user using emojis" do
     skip "emojis not supported"
-    send_message("What a nice emoji😀!", "hola mundo")
+    send_message(body: "What a nice emoji😀!", subject: "hola mundo")
 
     assert_content("What a nice emoji😀!")
     assert_content("Mover mensaje a papelera")
   end
 
   it "replies to a message" do
-    send_message("hola trololo", "hola mundo")
-    send_message("hola trululu")
+    send_message(body: "hola trololo", subject: "hola mundo")
+    send_message(body: "hola trululu")
 
     assert_content("hola trululu")
   end
 
   private
 
-  def send_message(body, subject = nil)
+  def send_message(params)
+    subject = params[:subject]
+
     fill_in("mailboxer_message_subject", with: subject) if subject
-    fill_in "mailboxer_message_body", with: body
+    fill_in "mailboxer_message_body", with: params[:body]
     click_button "Enviar"
   end
 end

--- a/test/integration/messages_test.rb
+++ b/test/integration/messages_test.rb
@@ -27,13 +27,13 @@ class MessagesTest < ActionDispatch::IntegrationTest
 
   it 'sends message after a previous error' do
     send_message(body: 'hola, user2')
-    send_message(body: 'hola, user2', subject: 'forgot the title')
+    send_message(subject: 'forgot the title', body: 'hola, user2')
 
     assert_content('Conversación con user2 asunto forgot the title')
   end
 
   it 'shows the other user in the conversation header' do
-    send_message(body: 'hola, user2', subject: 'Cosas')
+    send_message(subject: 'Cosas', body: 'hola, user2')
     assert_content('Conversación con user2')
 
     login_as @user2
@@ -43,7 +43,7 @@ class MessagesTest < ActionDispatch::IntegrationTest
   end
 
   it "messages another user" do
-    send_message(body: "hola trololo", subject: "hola mundo")
+    send_message(subject: "hola mundo", body: "hola trololo")
 
     assert_content("hola trololo")
     assert_content("Mover mensaje a papelera")
@@ -51,14 +51,14 @@ class MessagesTest < ActionDispatch::IntegrationTest
 
   it "messages another user using emojis" do
     skip "emojis not supported"
-    send_message(body: "What a nice emoji😀!", subject: "hola mundo")
+    send_message(subject: "hola mundo", body: "What a nice emoji😀!")
 
     assert_content("What a nice emoji😀!")
     assert_content("Mover mensaje a papelera")
   end
 
   it "replies to a message" do
-    send_message(body: "hola trololo", subject: "hola mundo")
+    send_message(subject: "hola mundo", body: "hola trololo")
     send_message(body: "hola trululu")
 
     assert_content("hola trululu")

--- a/test/integration/messages_test.rb
+++ b/test/integration/messages_test.rb
@@ -19,8 +19,15 @@ class MessagesTest < ActionDispatch::IntegrationTest
     assert_content('Título no puede estar en blanco')
   end
 
-  it 'shows errors when message has no body' do
+  it 'shows errors when creating conversation with empty message' do
     send_message(subject: 'hola, user2')
+
+    assert_content('Mensaje no puede estar en blanco')
+  end
+
+   it 'shows errors when replying to conversation with empty message' do
+    send_message(subject: 'hola, user2', body: 'How you doing?')
+    send_message(body: '')
 
     assert_content('Mensaje no puede estar en blanco')
   end


### PR DESCRIPTION
Fixes [crash](https://err.nolotiro.org/apps/571de5807a440000b2000005/problems/571e0407b41d4200a8000004) detected by errbit when the user replies to a conversation with an empty message.

