### PR TITLE
Dont show geolocated locations with less than city precision

### DIFF
--- a/app/helpers/geo_helper.rb
+++ b/app/helpers/geo_helper.rb
@@ -21,6 +21,7 @@ module GeoHelper
 
     city = suggestion.city
     city_name = city.name(I18n.locale) || city.name('en')
+    return unless city_name
 
     region = suggestion.subdivisions[0]
     region_name = region ? (region.name(I18n.locale) || region.name('en')) : ''

--- a/test/helpers/geo_helper_test.rb
+++ b/test/helpers/geo_helper_test.rb
@@ -3,14 +3,14 @@ require 'test_helper'
 class GeoHelperTest < ActionView::TestCase
   include GeoHelper
 
-  test "gets ip address" do
+  test "extracts ip address from request headers" do
     @request.headers["REMOTE_ADDR"] = "87.223.138.147"
     ip = GeoHelper.get_ip_address(@request)
 
     assert_equal("87.223.138.147", ip)
   end 
 
-  test "suggests location with ip address" do
+  test "suggests location from ip address" do
     suggestion = GeoHelper.suggest "8.8.8.8"
     assert_equal("Mountain View, California, Estados Unidos", suggestion)
   end

--- a/test/helpers/geo_helper_test.rb
+++ b/test/helpers/geo_helper_test.rb
@@ -3,19 +3,19 @@ require 'test_helper'
 class GeoHelperTest < ActionView::TestCase
   include GeoHelper
 
-  test "should get ip address" do
+  test "gets ip address" do
     @request.headers["REMOTE_ADDR"] = "87.223.138.147"
     ip = GeoHelper.get_ip_address(@request)
 
     assert_equal("87.223.138.147", ip)
   end 
 
-  test "should suggest location with ip address" do
+  test "suggests location with ip address" do
     suggestion = GeoHelper.suggest "8.8.8.8"
     assert_equal("Mountain View, California, Estados Unidos", suggestion)
   end
 
-  test "should suggest properly translated locations" do
+  test "suggests properly translated locations" do
     I18n.locale = :en
     suggestion = GeoHelper.suggest "8.8.8.8"
     assert_equal("Mountain View, California, United States", suggestion)

--- a/test/helpers/geo_helper_test.rb
+++ b/test/helpers/geo_helper_test.rb
@@ -21,4 +21,9 @@ class GeoHelperTest < ActionView::TestCase
     assert_equal("Mountain View, California, United States", suggestion)
     I18n.locale = :es
   end
+
+  test "does not suggests a location unless it's city-specific" do
+    # This ip address is correctly resolved to Brazil, but not a specific city
+    assert_nil GeoHelper.suggest "186.237.37.253"
+  end
 end


### PR DESCRIPTION
Según la IP que me asigna mi router, a veces Maxmind me geolocaliza bien, pero otras sólo es capaz de decirme que estoy en Brasil, pero no en qué ciudad o región. En esos caso, ignorar la sugerencia.

A nivel de interfaz

Antes

![captura de pantalla de 2016-06-20 13 42 15](https://cloud.githubusercontent.com/assets/2887858/16202759/81587d06-36ed-11e6-9b3d-2dc9e8e60112.png)

Después
![captura de pantalla de 2016-06-20 13 43 47](https://cloud.githubusercontent.com/assets/2887858/16202765/89461348-36ed-11e6-8b91-3f37509fad16.png)

