### PR TITLE
Enforce data integrity

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   has_many :identities, inverse_of: :user, dependent: :destroy
 
-  has_many :ads, foreign_key: 'user_owner'
+  has_many :ads, foreign_key: 'user_owner', dependent: :destroy
   has_many :comments, foreign_key: 'user_owner'
 
   has_many :friendships

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ActiveRecord::Base
   has_many :identities, inverse_of: :user, dependent: :destroy
 
   has_many :ads, foreign_key: 'user_owner', dependent: :destroy
-  has_many :comments, foreign_key: 'user_owner'
+  has_many :comments, foreign_key: 'user_owner', dependent: :destroy
 
   has_many :friendships
   has_many :friends, :through => :friendships

--- a/app/views/ads/_ad.html.erb
+++ b/app/views/ads/_ad.html.erb
@@ -1,53 +1,51 @@
-<% if ad.user %>
-  <div class="ad_excerpt_home">
-    <%= render "ads/actions", ad: ad %>
+<div class="ad_excerpt_home">
+  <%= render "ads/actions", ad: ad %>
 
-    <% if ad.image.exists? %>
-      <div class="ad_list_image">
-        <%= link_to adslug_path(ad,ad.slug) do %>
-          <%= image_tag ad.image.url(:thumb), title: ad.title, alt: ad.title %>
-        <% end %>
-      </div>
-    <% end %>
-
-    <h4>
+  <% if ad.image.exists? %>
+    <div class="ad_list_image">
       <%= link_to adslug_path(ad,ad.slug) do %>
-        <%= ad.title %>
-      <% end %>
-    </h4>
-    <div class="ad_excerpt_woeid">
-      <%= link_to ads_woeid_path(id: ad.woeid_code, type: ad.type_class) do %>
-        <%= ad.woeid_name %> &gt;
-        <%= ad.type_string %>
+        <%= image_tag ad.image.url(:thumb), title: ad.title, alt: ad.title %>
       <% end %>
     </div>
-    <% if ad.is_give? %>
-      <span class="ad_status <%= ad.status_class %>">
-        <%= ad.status_string %>
-      </span>
+  <% end %>
+
+  <h4>
+    <%= link_to adslug_path(ad,ad.slug) do %>
+      <%= ad.title %>
     <% end %>
-    <span class="ad_date">
-      <%= t('nlt.published_on_html', date: ad.published_at) %>
-      <%= t('nlt.by_user') %>
-      <%= link_to ad.user.username, listads_user_path(ad.user) %>
-    </span>
-    <div><p><%= truncate ad.body, length: 200, separator: ' ' %></p></div>
-    <div class="ad_meta_info">
-      <% if ad.status_class == 'available' %>
-        <b>
-          <%= link_to t('nlt.send_a_message'), message_new_with_subject_path(user_id: ad.user.id, subject: ad.slug) %>
-        </b>
-      <% end %>
-      <span class="right small">
-        &nbsp;&nbsp;
-        <%= t('nlt.readed_count', count: ad.readed_counter) %>
-        <% if ad.comments_count > 0 %>
-          <%= t('nlt.comments_count', count: ad.comments_count) %>
-        <% end %>
-      </span>
-    </div>
+  </h4>
+  <div class="ad_excerpt_woeid">
+    <%= link_to ads_woeid_path(id: ad.woeid_code, type: ad.type_class) do %>
+      <%= ad.woeid_name %> &gt;
+      <%= ad.type_string %>
+    <% end %>
   </div>
-<% end %>
+  <% if ad.is_give? %>
+    <span class="ad_status <%= ad.status_class %>">
+      <%= ad.status_string %>
+    </span>
+  <% end %>
+  <span class="ad_date">
+    <%= t('nlt.published_on_html', date: ad.published_at) %>
+    <%= t('nlt.by_user') %>
+    <%= link_to ad.user.username, listads_user_path(ad.user) %>
+  </span>
+  <div><p><%= truncate ad.body, length: 200, separator: ' ' %></p></div>
+  <div class="ad_meta_info">
+    <% if ad.status_class == 'available' %>
+      <b>
+        <%= link_to t('nlt.send_a_message'), message_new_with_subject_path(user_id: ad.user.id, subject: ad.slug) %>
+      </b>
+    <% end %>
+    <span class="right small">
+      &nbsp;&nbsp;
+      <%= t('nlt.readed_count', count: ad.readed_counter) %>
+      <% if ad.comments_count > 0 %>
+        <%= t('nlt.comments_count', count: ad.comments_count) %>
+      <% end %>
+    </span>
+  </div>
+</div>
 
 <% if defined? i %>
   <% if [ 5, 10, 15 ].include? i and ( defined? show_ads and show_ads ) %>

--- a/db/migrate/20160621154215_remove_orphan_ads.rb
+++ b/db/migrate/20160621154215_remove_orphan_ads.rb
@@ -1,0 +1,12 @@
+class RemoveOrphanAds < ActiveRecord::Migration
+  def change
+    reversible do |direction|
+      direction.up do
+        execute 'DELETE FROM ads WHERE user_owner NOT IN (SELECT id from users)'
+      end
+    end
+
+    add_index :ads, :user_owner
+    add_foreign_key :ads, :users, column: :user_owner
+  end
+end

--- a/db/migrate/20160621160507_remove_orphan_comments.rb
+++ b/db/migrate/20160621160507_remove_orphan_comments.rb
@@ -1,0 +1,14 @@
+class RemoveOrphanComments < ActiveRecord::Migration
+  def change
+    reversible do |direction|
+      direction.up do
+        execute <<-SQL.squish
+          DELETE FROM comments WHERE user_owner NOT IN (SELECT id from users)
+        SQL
+      end
+    end
+
+    add_index :comments, :user_owner
+    add_foreign_key :comments, :users, column: :user_owner
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160620123804) do
+ActiveRecord::Schema.define(version: 20160621154215) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace",     limit: 255
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20160620123804) do
   end
 
   add_index "ads", ["status"], name: "index_ads_on_status", using: :btree
+  add_index "ads", ["user_owner"], name: "index_ads_on_user_owner", using: :btree
   add_index "ads", ["woeid_code"], name: "woeid", using: :btree
 
   create_table "comments", force: :cascade do |t|
@@ -62,6 +63,7 @@ ActiveRecord::Schema.define(version: 20160620123804) do
   end
 
   add_index "comments", ["ads_id"], name: "ads_id", using: :btree
+  add_index "comments", ["user_owner"], name: "fk_rails_e9eda2acf7", using: :btree
 
   create_table "friendships", id: false, force: :cascade do |t|
     t.integer "user_id",   limit: 4, null: false
@@ -165,6 +167,7 @@ ActiveRecord::Schema.define(version: 20160620123804) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  add_foreign_key "ads", "users", column: "user_owner"
   add_foreign_key "identities", "users"
   add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
   add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160621154215) do
+ActiveRecord::Schema.define(version: 20160621160507) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace",     limit: 255
@@ -63,7 +63,7 @@ ActiveRecord::Schema.define(version: 20160621154215) do
   end
 
   add_index "comments", ["ads_id"], name: "ads_id", using: :btree
-  add_index "comments", ["user_owner"], name: "fk_rails_e9eda2acf7", using: :btree
+  add_index "comments", ["user_owner"], name: "index_comments_on_user_owner", using: :btree
 
   create_table "friendships", id: false, force: :cascade do |t|
     t.integer "user_id",   limit: 4, null: false
@@ -168,6 +168,7 @@ ActiveRecord::Schema.define(version: 20160621154215) do
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
   add_foreign_key "ads", "users", column: "user_owner"
+  add_foreign_key "comments", "users", column: "user_owner"
   add_foreign_key "identities", "users"
   add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
   add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"

--- a/test/factories/comment.rb
+++ b/test/factories/comment.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+
+  factory :comment do
+    body "Qué cosa buena que regalas!"
+    ad
+    ip "28.3.2.4"
+    user
+  end
+
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -84,6 +84,11 @@ class UserTest < ActiveSupport::TestCase
     assert_equal(user.active_for_authentication?, false)
   end
 
+  test "associated ads are deleted when user is deleted" do
+    FactoryGirl.create(:ad, user: @user)
+
+    assert_difference(-> { Ad.count }, -1) { @user.destroy }
+  end
 end
 
 class UserScopesTest < ActiveSupport::TestCase

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -89,6 +89,12 @@ class UserTest < ActiveSupport::TestCase
 
     assert_difference(-> { Ad.count }, -1) { @user.destroy }
   end
+
+  test "associated comments are deleted when user is deleted" do
+    FactoryGirl.create(:comment, user: @user)
+
+    assert_difference(-> { Comment.count }, -1) { @user.destroy }
+  end
 end
 
 class UserScopesTest < ActiveSupport::TestCase


### PR DESCRIPTION
Esta PR elimina más de 7000 comentarios y anuncios inválidos de la BD y añade las restricciones para no que no haya más datos huérfanos de este tipo en el futuro.

Please review!