### PR TITLE
Fix visual regression recently introduced

### DIFF
--- a/app/assets/stylesheets/adsense.sass
+++ b/app/assets/stylesheets/adsense.sass
@@ -4,6 +4,10 @@
 .google_ad_wrapper
   margin-top: 20px
 
+.google_ad_lateral_wrapper
+  margin-left: 50px
+  margin-top: 20px
+
 .google_adsense_320_100
   width: 320px
   height: 100px

--- a/app/views/messages/show.html.haml
+++ b/app/views/messages/show.html.haml
@@ -19,5 +19,5 @@
     = render :partial => "reply", :locals => {:message => @message}
   .span-8.mobile
     = render partial: "partials/google_adsense", locals: { class_name: "google_adsense_336_280", ad_slot: "7225596067"}
-  .span-7.desktop.google_ad_wrapper
+  .span-7.desktop.google_ad_lateral_wrapper
     = render partial: "partials/google_adsense", locals: { class_name: "google_adsense_300_250", ad_slot: "8702329269"}

--- a/app/views/users/listads.html.erb
+++ b/app/views/users/listads.html.erb
@@ -30,13 +30,13 @@
   </div>
 
   <div class="span-4 desktop">
-    <div class="google_ad_wrapper">
+    <div class="google_ad_lateral_wrapper">
       <%= render partial: "partials/google_adsense", locals: { class_name: "google_adsense_600_160", ad_slot: "6783776462"}  %>
     </div>
-    <div class="google_ad_wrapper">
+    <div class="google_ad_lateral_wrapper">
       <%= render partial: "partials/google_adsense", locals: { class_name: "google_adsense_600_160", ad_slot: "6783776462"}  %>
     </div>
-    <div class="google_ad_wrapper">
+    <div class="google_ad_lateral_wrapper">
       <%= render partial: "partials/google_adsense", locals: { class_name: "google_adsense_600_160", ad_slot: "6783776462"}  %>
     </div>
   </div>

--- a/app/views/woeid/show.html.erb
+++ b/app/views/woeid/show.html.erb
@@ -91,7 +91,7 @@
   </div><!-- /span-17 -->
 
   <div class="span-6 desktop">
-    <div class="google_ad_wrapper">
+    <div class="google_ad_lateral_wrapper">
       <%= render partial: "partials/google_adsense", locals: { class_name: "google_adsense_600_160", ad_slot: "6783776462"}  %>
     </div>
   </div><!-- /span-6 -->


### PR DESCRIPTION
Iba a desplegar master pero he encontrado una regresión visual introducida en  in 98993a3 tras probar primero en staging. Al arreglar la alineación de los anuncios en móvil me había cargado algunos márgenes en desktop.