### PR TITLE
Language best effort

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,7 +31,20 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale
-    I18n.locale = params[:locale] || I18n.default_locale
+    I18n.locale = params_locale || browser_locale || I18n.default_locale
+  end
+
+  def params_locale
+    params[:locale].presence
+  end
+
+  def browser_locale
+    return unless request.env['HTTP_ACCEPT_LANGUAGE'].present?
+
+    lang = request.env['HTTP_ACCEPT_LANGUAGE'][/^[a-z]{2}/].to_sym
+    return unless I18n.available_locales.include?(lang)
+
+    lang
   end
 
   def default_url_options(options={})

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,6 @@ require 'sidekiq/web'
 NolotiroOrg::Application.routes.draw do
 
   ActiveAdmin.routes(self)
-  get '/', to: redirect('/es')
 
   scope '/api' do
     scope '/v1' do

--- a/test/integration/application_controller_test.rb
+++ b/test/integration/application_controller_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class ApplicationControllerTest < ActionDispatch::IntegrationTest
+  before { @old_locale = I18n.locale }
+
+  after { I18n.locale = @old_locale }
+
+  it 'assigns locale from param if available' do
+    get root_path(locale: 'pt'), {}, 'HTTP_ACCEPT_LANGUAGE' => 'it'
+
+    assert_equal :pt, I18n.locale
+  end
+
+  it 'assigns locale from browser if no param & browser locale available' do
+    get root_path(locale: nil), {}, 'HTTP_ACCEPT_LANGUAGE' => 'it'
+
+    assert_equal :it, I18n.locale
+  end
+
+  it 'fallback to default locale if no param & browser locale unavailable' do
+    get root_path(locale: nil), {}, 'HTTP_ACCEPT_LANGUAGE' => 'ch'
+
+    assert_equal I18n.default_locale, I18n.locale
+  end
+
+  it 'falls back to default locale if no param & no browser locale' do
+    get root_path(locale: nil)
+
+    assert_equal I18n.default_locale, I18n.locale
+  end
+end


### PR DESCRIPTION
Fixes #326.

De momento sólo pillamos el lenguaje del header `HTTP_ACCEPT_LANGUAGE`, pero se podría refinar más.