### PR TITLE
Google timeouts

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,11 +42,6 @@ module ApplicationHelper
     end
   end
 
-  def get_location_options(woeid)
-    # receives a woeid, returns a list of names like it
-    WoeidHelper.search_by_name(woeid.to_s)
-  end
-
   def i18n_to_localeapp_in_locale(locale)
     langs = {
       gl: 20650,

--- a/app/helpers/woeid_helper.rb
+++ b/app/helpers/woeid_helper.rb
@@ -47,7 +47,12 @@ module WoeidHelper
         locations = GeoPlanet::Place.search(name, :lang => locale, :type => 7, :count => 0)
         return if locations.nil?
 
-        places = locations.map {|l| ["#{convert_woeid_name(l.woeid)[:full]} (#{Ad.where(woeid_code: l.woeid).count} anuncios)", l.woeid] }
+        places = locations.map do |l|
+          name = convert_woeid_name(l.woeid)[:full]
+          count = "#{Ad.where(woeid_code: l.woeid).count} anuncios"
+
+          ["#{name} (#{count})", l.woeid]
+        end
         Rails.cache.write(key, places)
         return places
       end

--- a/app/helpers/woeid_helper.rb
+++ b/app/helpers/woeid_helper.rb
@@ -24,7 +24,7 @@ module WoeidHelper
           else
             return nil
           end
-      rescue
+      rescue GeoPlanet::NotFound
         return nil
       end
     end

--- a/app/helpers/woeid_helper.rb
+++ b/app/helpers/woeid_helper.rb
@@ -45,15 +45,15 @@ module WoeidHelper
         return Rails.cache.fetch(key)
       else
         GeoPlanet.appid = Rails.application.secrets["geoplanet_app_id"]
-        locations = GeoPlanet::Place.search(name, :lang => locale, :type => 7, :count => 0)
-        return if locations.nil?
+        raw_locations = GeoPlanet::Place.search(name, :lang => I18n.locale, :type => 7, :count => 0)
+        return if raw_locations.nil?
 
-        places = locations.map do |l|
-          l = YahooLocation.new(l)
-          name = l.fullname
-          count = I18n.t('nlt.ads.count', count: l.ads_count)
+        places = raw_locations.map do |raw_location|
+          location = YahooLocation.new(raw_location)
+          name = location.fullname
+          count = I18n.t('nlt.ads.count', count: location.ads_count)
 
-          ["#{name} (#{count})", l.woeid]
+          ["#{name} (#{count})", location.woeid]
         end
         Rails.cache.write(key, places)
         return places

--- a/app/helpers/woeid_helper.rb
+++ b/app/helpers/woeid_helper.rb
@@ -49,7 +49,7 @@ module WoeidHelper
 
         places = locations.map do |l|
           name = convert_woeid_name(l.woeid)[:full]
-          count = "#{Ad.where(woeid_code: l.woeid).count} anuncios"
+          count = I18n.t('nlt.ads.count', count: Ad.where(woeid_code: l.woeid).count)
 
           ["#{name} (#{count})", l.woeid]
         end

--- a/app/helpers/woeid_helper.rb
+++ b/app/helpers/woeid_helper.rb
@@ -38,25 +38,18 @@ module WoeidHelper
     #                      example: [["Madrid, Madrid, España (2444 anuncios)",766273],["Madrid, Comunidad de Madrid, España (444 anuncios)",12578024],["Madrid, Cundinamarca, Colombia (0 anuncios)",361938]]
     #
 
-    locale = I18n.locale;
     if name
-      key = 'location_' + locale.to_s + '_' + name
-      if Rails.cache.fetch(key)
-        return Rails.cache.fetch(key)
-      else
-        GeoPlanet.appid = Rails.application.secrets["geoplanet_app_id"]
-        raw_locations = GeoPlanet::Place.search(name, :lang => I18n.locale, :type => 7, :count => 0)
-        return if raw_locations.nil?
+      GeoPlanet.appid = Rails.application.secrets["geoplanet_app_id"]
+      raw_locations = GeoPlanet::Place.search(name, :lang => I18n.locale, :type => 7, :count => 0)
+      return if raw_locations.nil?
 
-        places = raw_locations.map do |raw_location|
-          location = YahooLocation.new(raw_location)
-          name = location.fullname
-          count = I18n.t('nlt.ads.count', count: location.ads_count)
+      raw_locations.map do |raw_location|
+        location = YahooLocation.new(raw_location)
 
-          ["#{name} (#{count})", location.woeid]
-        end
-        Rails.cache.write(key, places)
-        return places
+        name = location.fullname
+        count = I18n.t('nlt.ads.count', count: location.ads_count)
+
+        ["#{name} (#{count})", location.woeid]
       end
     else
       nil

--- a/app/models/yahoo_location.rb
+++ b/app/models/yahoo_location.rb
@@ -1,0 +1,28 @@
+#
+# Wraper around GeoPlanet::Place
+#
+class YahooLocation
+  def initialize(place)
+    @place = place
+  end
+
+  def fullname
+    "#{@place.name}, #{@place.admin1}, #{@place.country}"
+  end
+
+  def name
+    @place.name
+  end
+
+  def ads_count
+    Ad.where(woeid_code: woeid).count
+  end
+
+  def woeid
+    @place.woeid
+  end
+
+  def town?
+    @place.placetype_code == 7
+  end
+end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -276,6 +276,9 @@ ca:
       unlock_user: "[ADMIN] Desbloca a aquest usuari"
     ads:
       bumped: 
+      count:
+        one: "%{count} anunci"
+        other: "%{count} anuncis"
       created: Hem creat l'anunci
       form:
         body: 'Cos de l''anunci:'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -276,6 +276,9 @@ de:
       unlock_user: 
     ads:
       bumped: 
+      count:
+        one: 
+        other: 
       created: 
       form:
         body: 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -272,6 +272,9 @@ en:
       unlock_user: "[ADMIN] Unblock this user"
     ads:
       bumped: 
+      count:
+        one: "%{count} ad"
+        other: "%{count} ads"
       created: We have created the ad
       form:
         body: 'Body of the ad:'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -276,6 +276,9 @@ es:
       unlock_user: "[ADMIN] Desbloquear a este usuario"
     ads:
       bumped: Hemos republicado el anuncio
+      count:
+        one: "%{count} anuncio"
+        other: "%{count} anuncios"
       created: Hemos creado el anuncio
       form:
         body: 'Cuerpo del anuncio:'

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -276,6 +276,9 @@ eu:
       unlock_user: 
     ads:
       bumped: 
+      count:
+        one: 
+        other: 
       created: 
       form:
         body: 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -278,6 +278,9 @@ fr:
       unlock_user: 
     ads:
       bumped: 
+      count:
+        one: 
+        other: 
       created: 
       form:
         body: 

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -287,6 +287,9 @@ gl:
       unlock_user: 
     ads:
       bumped: 
+      count:
+        one: "%{count} anuncio"
+        other: "%{count} anuncios"
       created: Creamos o anuncio
       form:
         body: 'Corpo do anuncio:'

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -276,6 +276,9 @@ it:
       unlock_user: "[ADMIN] Sbloccare a questo utente"
     ads:
       bumped: Abbiamo ripubblicato annuncio
+      count:
+        one: "%{count} annuncio"
+        other: "%{count} annunci"
       created: 'Abbiamo creato l''annuncio '
       form:
         body: Corpo del annuncio

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -266,6 +266,9 @@ nl:
       unlock_user: 
     ads:
       bumped: 
+      count:
+        one: 
+        other: 
       created: 
       form:
         body: 

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -276,6 +276,9 @@ pt:
       unlock_user: "[ADMIN] Desbloquear este usuario"
     ads:
       bumped: Anúncio republicado
+      count:
+        one: "%{count} anúncio"
+        other: "%{count} anúncios"
       created: Anúncio criado
       form:
         body: 'Corpo de anúncio:'

--- a/test/fixtures/vcr_cassettes/woeid_222222_info_es.yml
+++ b/test/fixtures/vcr_cassettes/woeid_222222_info_es.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://where.yahooapis.com/v1/place/222222?appid=ccc2c6d8c5c9233d952dee39e4e4f05266d3ebc47b809498a7b071b500aefccd269423a8967b3d96700d5c1a630d59159b2b8f4d111714a8fb777362e548bc57&format=json&lang=es
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 28 Jun 2016 11:44:39 GMT
+      P3p:
+      - policyref="https://policies.yahoo.com/w3c/p3p.xml", CP="CAO DSP COR CUR ADM
+        DEV TAI PSA PSD IVAi IVDi CONi TELo OTPi OUR DELi SAMi OTRi UNRi PUBi IND
+        PHY ONL UNI PUR FIN COM NAV INT DEM CNT STA POL HEA PRE LOC GOV"
+      Content-Language:
+      - en-US
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - max-age=86400,public
+      Expires:
+      - Wed, 29 Jun 2016 11:44:39 GMT
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '168'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Age:
+      - '2'
+      Connection:
+      - keep-alive
+      Via:
+      - http/1.1 r1.ycpi.br1.yahoo.net (ApacheTrafficServer [cSsSfU])
+      Server:
+      - ATS
+      Y-Trace:
+      - BAEAQAAAAAC_rS_suwEzPwAAAAAAAAAAjqBCm.EuOsoAAAAAAAAAAAAFNlUpe06OAAU2VSmBS082RLLQAAAAAA--
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA22OMQvCMBSE/8rjzdqodOqqrg6KW5aQPk0g5oWX1Cql/91Q
+        EBdvu7vv4CYkERbsJhzEY4eulNRppdU4js3bOGaTfG4sP7R6brVa8KxVu2lx
+        hcHEex1RXF8v1faUrfhUPMeaVgTOlHkQS3BgynDiAseXz2Vhi/GhYnseQg+x
+        VjcfeyiOQL6r3xtHQv/+pGAsabVbhPP8AXyYVoTRAAAA
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 11:44:40 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/woeid_23424801_info_es.yml
+++ b/test/fixtures/vcr_cassettes/woeid_23424801_info_es.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://where.yahooapis.com/v1/place/23424801?appid=ccc2c6d8c5c9233d952dee39e4e4f05266d3ebc47b809498a7b071b500aefccd269423a8967b3d96700d5c1a630d59159b2b8f4d111714a8fb777362e548bc57&format=json&lang=es
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 28 Jun 2016 11:44:39 GMT
+      P3p:
+      - policyref="https://policies.yahoo.com/w3c/p3p.xml", CP="CAO DSP COR CUR ADM
+        DEV TAI PSA PSD IVAi IVDi CONi TELo OTPi OUR DELi SAMi OTRi UNRi PUBi IND
+        PHY ONL UNI PUR FIN COM NAV INT DEM CNT STA POL HEA PRE LOC GOV"
+      Content-Language:
+      - es
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - max-age=86400,public
+      Expires:
+      - Wed, 29 Jun 2016 11:44:39 GMT
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '311'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      Via:
+      - http/1.1 r2.ycpi.br1.yahoo.net (ApacheTrafficServer [cSsSfU])
+      Server:
+      - ATS
+      Y-Trace:
+      - BAEAQAAAAAB7iKZXYReQSwAAAAAAAAAAlI_BR6r0OagAAAAAAAAAAAAFNlUpc2mqAAU2VSl5nTpwtcypAAAAAA--
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA21Ry07DMBD8FeRzcWznVXoE9YoQQuKSy+JYjUXqjewNJary
+        79ikFRBxm33MzD7ObOhBG7Y7sxMa27KdygtVbIXcLJWXaTCPcIwd7AmaUQjT
+        Braq3QCRD0lDYxs7pZo3zC2kvR6hRR8pGkdHfvov9yNAUXJltWiy/UPEqxmj
+        DbRH62SsswtWv3C+4B419JYm+Te8dA4YCPoFaxPHwWRxZj2QpTF530peb2VZ
+        Jao7XJP1lktRVVUdp3iLe7TWHe7xM1EDjtS9mkArnZILWefFX507yatKqiLd
+        DD11e1jzJC/KQsmVfcmVEKLO53QFb+AZ3HvsTY/DYQnEho3extU6omHXZE12
+        6ow3fIIOEQYbuMZjk33IJvt+aJNdL5vOBO4QqSawef4CNxCTjCcCAAA=
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 11:44:39 GMT
+recorded_with: VCR 3.0.3

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -8,17 +8,6 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal(escape_privacy_data(text), expected_text)
   end
 
-  test "should get_location_options" do
-    skip
-  #  result = get_location_options 766275
-  #  expected_result = [["7662, Transisalania, Países Bajos (0 anuncios)", 12852904], ["766, Orissa, India (0 anuncios)", 24551724], ["76, Región Noroeste de Singapur, Singapur (0 anuncios)", 24703068]]
-  #  assert_equal expected_result, result
-
-  #  result = get_location_options 716271
-  #  expected_result = [["Gordale, Liguria, Italia (0 anuncios)", 716271]]
-  #  assert_equal expected_result, result
-  end
-
   test "should i18n_to_localeapp_in_locale, :en" do
     assert_equal 20647, i18n_to_localeapp_in_locale(:en)
   end

--- a/test/helpers/woeid_helper_test.rb
+++ b/test/helpers/woeid_helper_test.rb
@@ -4,6 +4,8 @@ require 'support/web_mocking'
 class WoeidHelperTest < ActionView::TestCase
   include WebMocking
 
+  after { Rails.cache.clear }
+
   test "converts a WOEID to a place name in the given format" do
     mocking_yahoo_woeid_info(766273) do
       location = WoeidHelper.convert_woeid_name(766273)

--- a/test/helpers/woeid_helper_test.rb
+++ b/test/helpers/woeid_helper_test.rb
@@ -4,7 +4,7 @@ require 'support/web_mocking'
 class WoeidHelperTest < ActionView::TestCase
   include WebMocking
 
-  test "should convert a WOEID to a place name in the given format" do
+  test "converts a WOEID to a place name in the given format" do
     mocking_yahoo_woeid_info(766273) do
       location = WoeidHelper.convert_woeid_name(766273)
       assert_equal("Madrid, Madrid, España", location[:full])
@@ -12,7 +12,7 @@ class WoeidHelperTest < ActionView::TestCase
     end
   end
 
-  test "should search serveral cities with the same name" do
+  test "searches serveral cities with the same name" do
     mocking_yahoo_woeid_similar("tenerife") do
       actual = WoeidHelper.search_by_name("tenerife") 
       expected = [

--- a/test/helpers/woeid_helper_test.rb
+++ b/test/helpers/woeid_helper_test.rb
@@ -12,7 +12,7 @@ class WoeidHelperTest < ActionView::TestCase
     end
   end
 
-  test "searches serveral cities with the same name" do
+  test "suggests cities with similar names" do
     mocking_yahoo_woeid_similar("tenerife") do
       actual = WoeidHelper.search_by_name("tenerife") 
       expected = [

--- a/test/integration/woeid_test.rb
+++ b/test/integration/woeid_test.rb
@@ -18,10 +18,10 @@ class WoeidTest < ActionDispatch::IntegrationTest
     end
   end
 
-  it "returns a hard 404 error if woeid is not a valid woeid" do
+  it "returns a hard 404 error if woeid does not exist" do
     mocking_yahoo_woeid_info(222222) do
       assert_raise(ActionController::RoutingError) do
-        get '/es/woeid/222222/give' #woeid does not exist
+        get '/es/woeid/222222/give'
       end
     end
   end

--- a/test/integration/woeid_test.rb
+++ b/test/integration/woeid_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class WoeidUrlParamValid < ActionDispatch::IntegrationTest
+class WoeidTest < ActionDispatch::IntegrationTest
 
   it "returns a hard 404 error if woeid is not type town" do
     assert_raise(ActionController::RoutingError) do

--- a/test/integration/woeid_test.rb
+++ b/test/integration/woeid_test.rb
@@ -1,10 +1,14 @@
 require "test_helper"
+require "support/web_mocking"
 
 class WoeidTest < ActionDispatch::IntegrationTest
+  include WebMocking
 
   it "returns a hard 404 error if woeid is not type town" do
-    assert_raise(ActionController::RoutingError) do
-      get '/es/woeid/23424801/give' #woeid of Ecuador Country
+    mocking_yahoo_woeid_info(23424801) do
+      assert_raise(ActionController::RoutingError) do
+        get '/es/woeid/23424801/give' #woeid of Ecuador Country
+      end
     end
   end
 
@@ -15,8 +19,10 @@ class WoeidTest < ActionDispatch::IntegrationTest
   end
 
   it "returns a hard 404 error if woeid is not a valid woeid" do
-    assert_raise(ActionController::RoutingError) do
-      get '/es/woeid/222222/give' #woeid does not exist
+    mocking_yahoo_woeid_info(222222) do
+      assert_raise(ActionController::RoutingError) do
+        get '/es/woeid/222222/give' #woeid does not exist
+      end
     end
   end
 


### PR DESCRIPTION
Los bots de google están dando timeouts en páginas de ciertos woeid sin anuncios y con un alto número de ciudades con nombre similar. Esto es porque hasta ahora en la página que sugiere ciudades con nombres similares cuando no hay anuncios, lo que hacíamos era primero una llamada a la API de Yahoo para obtener las ciudades similares, y luego por cada woeid alternativo encontrado, una llamada a la API de Yahoo para obtener su nombre en formato "Ciudad, Region, País". Los timeouts son de esperar en ciudades con ~500 alternativas...

La solución consiste en tocar la API de Yahoo una sola vez, puesto que la información que necesitamos ya la provee la primera llamada.