### PR TITLE
Handle duplicated usernames in oauth registration

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,14 +20,11 @@ class ApplicationController < ActionController::Base
     redirect_to root_url, :alert => exception.message
   end
 
-  def after_sign_in_path_for(resource)
-    # https://github.com/plataformatec/devise/wiki/How-To:-Redirect-to-a-specific-page-on-successful-sign-in
-    if request.referer and ["user/reset/edit", new_user_session_url].any? {|w| request.referer.include? w }
-      super
-    else
-      initial_path = current_user.woeid? ? ads_woeid_path(id: current_user.woeid, type: 'give') : location_ask_path
-      stored_location_for(resource) || request.referer || initial_path
-    end
+  def signed_in_root_path(resource)
+    woeid = resource.woeid
+    return ads_woeid_path(id: woeid, type: 'give') if woeid
+
+    location_ask_path
   end
 
   def set_locale

--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -1,11 +1,11 @@
 class CallbacksController < Devise::OmniauthCallbacksController
 
   def facebook
-    if oauth_user
+    if oauth_user.valid?
       sign_in_and_redirect
     else
       session['devise.omniauth_data'] = oauth
-      redirect_to new_user_registration_path
+      redirect_to new_user_registration_path, alert: flash_message
     end
   end
 
@@ -15,7 +15,16 @@ class CallbacksController < Devise::OmniauthCallbacksController
 
   private
 
+  def flash_message
+    if oauth_user.errors.keys.include?(:email)
+      I18n.t('oauth.errors.email_not_provided')
+    else
+      I18n.t('oauth.errors.duplicated_username', provider: oauth['provider'])
+    end
+  end
+
   def sign_in_and_redirect
+    oauth_user.save!
     sign_in oauth_user
     redirect_to root_url
   end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -18,4 +18,10 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   helper_method :omniauth_registration?
+
+  def omniauth_email?
+    omniauth_registration? && session['devise.omniauth_data']['info']['email']
+  end
+
+  helper_method :omniauth_email?
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -11,6 +11,8 @@ class RegistrationsController < Devise::RegistrationsController
     end
   end
 
+  private
+
   def omniauth_registration?
     session['devise.omniauth_data']
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -74,12 +74,6 @@ module ApplicationHelper
     url_for(params.merge(locale: locale, only_path: false))
   end
 
-  def registration_header
-    event = omniauth_registration? ? 'finalize_registration' : 'become_member'
-
-    t("nlt.please_fill_to_#{event}")
-  end
-
   def errors_for(object)
     errs = object.errors
     return unless errs.any?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,9 +42,10 @@ class User < ActiveRecord::Base
     oauth = OmniAuth::AuthHash.new(oauth_session)
 
     new do |u|
-      u.email = params[:email]
+      u.email = params[:email] || oauth.info.email
       u.username = params[:username] || oauth.info.name
       u.identities.build(provider: oauth.provider, uid: oauth.uid)
+      u.confirmed_at = Time.zone.now if oauth.info.email
     end
   end
 

--- a/app/services/oauthenticator_service.rb
+++ b/app/services/oauthenticator_service.rb
@@ -14,7 +14,7 @@ class OauthenticatorService
 
     user = User.find_or_initialize_by(email: email) do |u|
       u.username = username
-      u.confirm
+      u.confirmed_at = Time.zone.now
     end
 
     user.identities.build(provider: provider, uid: uid)

--- a/app/services/oauthenticator_service.rb
+++ b/app/services/oauthenticator_service.rb
@@ -10,19 +10,20 @@ class OauthenticatorService
     identity = Identity.find_by(provider: provider, uid: uid)
     return identity.user if identity
 
-    return unless email
-
     user = User.find_or_initialize_by(email: email) do |u|
       u.username = username
       u.confirmed_at = Time.zone.now
     end
 
     user.identities.build(provider: provider, uid: uid)
-    user.save!
     user
   end
 
   private
+
+  def ambiguous_info?
+    email.nil? || User.exists?(username: username)
+  end
 
   def provider
     @oauth.provider

--- a/app/views/devise/registrations/_new_form.html.erb
+++ b/app/views/devise/registrations/_new_form.html.erb
@@ -1,3 +1,8 @@
+<%
+  # @todo: split new and finalize into 2 different forms and actions.
+  # This template is too cluttered
+%>
+
 <%= form_for(resource, :as => resource_name, :url => registration_path(resource_name)) do |f| %>
   <fieldset>
     <div class="col-md-6 col-sm-6">

--- a/app/views/devise/registrations/_new_form.html.erb
+++ b/app/views/devise/registrations/_new_form.html.erb
@@ -3,12 +3,14 @@
     <div class="col-md-6 col-sm-6">
       <%= devise_error_messages! %>
       <dl>
-        <dt>
-          <%= f.label :email, t('nlt.your_email') %>
-        </dt>
-        <dd>
-          <%= f.email_field :email, :autofocus => true, :required => true %>
-        </dd>
+        <% unless omniauth_email? %>
+          <dt>
+            <%= f.label :email, t('nlt.your_email') %>
+          </dt>
+          <dd>
+            <%= f.email_field :email, :autofocus => true, :required => true %>
+          </dd>
+        <% end %>
 
         <% unless omniauth_registration? %>
           <dt>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,10 +1,12 @@
 <% content_for(:meta_title, t('nlt.new_user')) %>
 
-<div id="default_header_section">
-  <h1><%= registration_header %></h1><br><br>
-  (<%= t 'nlt.if_youre_already_an_user' %>&nbsp;
-  <%= link_to t('nlt.access_here'), new_user_session_path, :title => "user login" %>)
-</div>
+<% unless omniauth_registration? %>
+  <div id="default_header_section">
+    <h1><%= I18n.t('nlt.please_fill_to_become_member') %></h1><br><br>
+    (<%= t 'nlt.if_youre_already_an_user' %>&nbsp;
+    <%= link_to t('nlt.access_here'), new_user_session_path, :title => "user login" %>)
+  </div>
+<% end %>
 
 <div class="col-md-9 col-sm-9">
   <div class="row">

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -523,6 +523,10 @@ ca:
     precision:
       format:
         delimiter: "."
+  oauth:
+    errors:
+      email_not_provided: 
+      duplicated_username: 
   recaptcha:
     errors:
       incorrect-captcha-sol: Hi va haver un error omplint els caràcters del captcha.

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -408,7 +408,6 @@ ca:
     password: Contrasenya
     permission_denied: No tens permisos per a realitzar aquesta acció.
     please_fill_to_become_member: Si us plau, ompli aquest formulari per ser membre de nolotiro
-    please_fill_to_finalize_registration: Si us plau, completa aquest formulari per finalitzar el registre
     please_insert_email_and_password: Si us plau posa el teu email i contrasenya.
     please_introduce: 'Si us plau, introdueix els caràcters que vegis:'
     privacy: política de privacitat

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -527,6 +527,10 @@ de:
     precision:
       format:
         delimiter: 
+  oauth:
+    errors:
+      email_not_provided: 
+      duplicated_username: 
   recaptcha:
     errors:
       incorrect-captcha-sol: 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -408,7 +408,6 @@ de:
     password: 
     permission_denied: 
     please_fill_to_become_member: 
-    please_fill_to_finalize_registration: 
     please_insert_email_and_password: 
     please_introduce: 
     privacy: 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -408,7 +408,6 @@ en:
     password: Password
     permission_denied: You don't have permissions
     please_fill_to_become_member: Please, fill this form to become a member
-    please_fill_to_finalize_registration: Please, fill this form to finalize registration
     please_insert_email_and_password: Please, insert your email and password
     please_introduce: Please, insert the following characters
     privacy: privacy policy

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -523,6 +523,10 @@ en:
     precision:
       format:
         delimiter: 
+  oauth:
+    errors:
+      email_not_provided: We need you to provide us with an email address to complete the registration process
+      duplicated_username: The username provided by %{provider} is already in our database. If you already registered through another social network or through email & password, please login using those. Otherwise just specify another username.
   recaptcha:
     errors:
       incorrect-captcha-sol: There is a mistake in your captcha's answer

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -523,6 +523,10 @@ es:
     precision:
       format:
         delimiter: "."
+  oauth:
+    errors:
+      email_not_provided: Necesitamos que indiques una dirección de email para completar el registro.
+      duplicated_username: Tu nombre de usuario de %{provider} ya se encuentra en nuestra base de datos. Si te has registrado ya usando otra red social o mediante email y contraseña, por favor, inicia sesión de esa manera. En caso contrario, indica otro nombre de usuario para completar el registro.
   recaptcha:
     errors:
       incorrect-captcha-sol: Hubo un error rellenando los caracteres del captcha.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -408,7 +408,6 @@ es:
     password: Contraseña
     permission_denied: No tienes permisos para realizar esta acción.
     please_fill_to_become_member: Por favor, rellena este formulario para ser miembro de nolotiro
-    please_fill_to_finalize_registration: Por favor, rellena este formulario para finalizar el registro
     please_insert_email_and_password: Por favor pon tu email y contraseña.
     please_introduce: 'Por favor, introduce los caracteres que veas:'
     privacy: política de privacidad

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -408,7 +408,6 @@ eu:
     password: 
     permission_denied: 
     please_fill_to_become_member: 
-    please_fill_to_finalize_registration: 
     please_insert_email_and_password: 
     please_introduce: 
     privacy: 

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -523,6 +523,10 @@ eu:
     precision:
       format:
         delimiter: 
+  oauth:
+    errors:
+      email_not_provided: 
+      duplicated_username: 
   recaptcha:
     errors:
       incorrect-captcha-sol: 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -410,7 +410,6 @@ fr:
     password: 
     permission_denied: 
     please_fill_to_become_member: 
-    please_fill_to_finalize_registration: 
     please_insert_email_and_password: 
     please_introduce: 
     privacy: 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -525,6 +525,10 @@ fr:
     precision:
       format:
         delimiter: 
+  oauth:
+    errors:
+      email_not_provided: 
+      duplicated_username: 
   recaptcha:
     errors:
       incorrect-captcha-sol: 

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -540,6 +540,10 @@ gl:
     precision:
       format:
         delimiter: 
+  oauth:
+    errors:
+      email_not_provided: 
+      duplicated_username: 
   recaptcha:
     errors:
       incorrect-captcha-sol: 

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -425,7 +425,6 @@ gl:
     password: Contrasinal
     permission_denied: 
     please_fill_to_become_member: Por favor, enche este formulario para facer membro do nolotiro
-    please_fill_to_finalize_registration: Por favor, enche este formulario para finalizar o registro
     please_insert_email_and_password: Por favor, engada o seu correo electrónico e contrasinal.
     please_introduce: 'Por favor, introduza os caracteres que aparecen:'
     privacy: política de privacidade

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -529,6 +529,10 @@ it:
     precision:
       format:
         delimiter: 
+  oauth:
+    errors:
+      email_not_provided: Abbiamo bisigno di un indirizzo de correo electronico per completare l'iscrizione.
+      duplicated_username: Il tuo username di %{provider} è gia nella nostra basi de dati. Se ti sei iscrito usando un'altra rete sociale oppure email e password, fai login usando quello. Altrimenti, inserisci un'altro username.
   recaptcha:
     errors:
       incorrect-captcha-sol: C'è stato un errore riempire i caratteri captcha.

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -412,7 +412,6 @@ it:
     password: password
     permission_denied: Non si dispone dell'autorizzazione per eseguire questa azione.
     please_fill_to_become_member: Si prega di compilare questo modulo per essere un membro di nolotiro
-    please_fill_to_finalize_registration: Si prega di compilare questo module per finire l'inscrizione
     please_insert_email_and_password: Metta prego la tua email e la password.
     please_introduce: 'Inserisci i caratteri che vedi:'
     privacy: politica sulla privacy

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -398,7 +398,6 @@ nl:
     password: 
     permission_denied: 
     please_fill_to_become_member: 
-    please_fill_to_finalize_registration: 
     please_insert_email_and_password: 
     please_introduce: 
     privacy: 

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -513,6 +513,10 @@ nl:
     precision:
       format:
         delimiter: 
+  oauth:
+    errors:
+      email_not_provided: 
+      duplicated_username: 
   recaptcha:
     errors:
       incorrect-captcha-sol: 

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -408,7 +408,6 @@ pt:
     password: Senha
     permission_denied: Você não tem permissão para executar esta ação
     please_fill_to_become_member: Por favor, preencha este formulário para se tornar um miembro do nolotiro
-    please_fill_to_finalize_registration: 
     please_insert_email_and_password: Por favor insira o seu email e a senha
     please_introduce: Por favor, insira os caracteres que você vê
     privacy: política de privacidade

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -533,6 +533,10 @@ pt:
     precision:
       format:
         delimiter: 
+  oauth:
+    errors:
+      email_not_provided: 
+      duplicated_username: 
   recaptcha:
     errors:
       incorrect-captcha-sol: 

--- a/test/integration/facebook_dup_username_registration_test.rb
+++ b/test/integration/facebook_dup_username_registration_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+require 'support/oauth'
+require 'support/web_mocking'
+
+class FacebookDupUsernameRegistrationTest < ActionDispatch::IntegrationTest
+  include OauthHelpers
+  include WebMocking
+
+  before do
+    create(:user, username: 'pepe', email: 'pepe@example.org')
+    login_via_facebook(name: 'pepe', email: 'pepe@facebook.com')
+  end
+
+  it 'redirects to a form' do
+    assert_content <<~MSG
+      Tu nombre de usuario de facebook ya se encuentra en nuestra base de datos.
+      Si te has registrado ya usando otra red social o mediante email y
+      contraseña, por favor, inicia sesión de esa manera. En caso contrario,
+      indica otro nombre de usuario para completar el registro.
+    MSG
+  end
+
+  it 'finalizes registration properly' do
+    fill_in 'Elige un nombre de usuario', with: 'pepe_nolotiro'
+    click_button 'Regístrate'
+
+    assert_content 'hola, pepe_nolotiro'
+  end
+end

--- a/test/integration/facebook_emailless_registration_test.rb
+++ b/test/integration/facebook_emailless_registration_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+require 'support/oauth'
+
+class FacebookEmaillessRegistrationTest < ActionDispatch::IntegrationTest
+  include OauthHelpers
+
+  before { login_via_facebook(name: 'pepe') }
+
+  it 'redirects to a form' do
+    assert_content <<~MSG
+      Necesitamos que indiques una dirección de email para completar el registro
+    MSG
+  end
+
+  it 'autofills username' do
+    assert page.has_selector?('input[value=pepe]')
+  end
+
+  it 'finishes registration' do
+    fill_in_finalize_form('pepe@facebook.com')
+
+    assert_content <<~MSG
+      Se ha enviado un mensaje con un enlace de confirmación a tu correo
+      electrónico.
+    MSG
+  end
+
+  it 'allows overriding facebook name in form' do
+    fill_in_finalize_form('pepe@facebook.com', 'pepito')
+
+    assert_equal ['pepito'], User.pluck(:username)
+  end
+
+  it 'requires user to confirm email' do
+    fill_in_finalize_form('pepe@facebook.com')
+    login_via_facebook(name: 'pepe')
+
+    assert_content 'Tienes que confirmar tu cuenta para poder continuar'
+  end
+
+  it 'logs user in after confirming email' do
+    fill_in_finalize_form('pepe@facebook.com')
+    User.first.confirm
+    login_via_facebook(name: 'pepe')
+
+    assert_content 'hola, pepe'
+  end
+
+  private
+
+  def fill_in_finalize_form(email, name = nil)
+    fill_in 'Tu email', with: email
+    fill_in 'Elige un nombre de usuario', with: name if name
+    click_button 'Regístrate'
+  end
+end

--- a/test/integration/facebook_registration_test.rb
+++ b/test/integration/facebook_registration_test.rb
@@ -12,50 +12,6 @@ class FacebookRegistrationTest < ActionDispatch::IntegrationTest
     assert_content 'hola, pepe'
   end
 
-  it 'redirects to a form when facebook account has no email' do
-    login_via_facebook(name: 'pepe')
-
-    assert_content <<~MSG
-      Necesitamos que indiques una dirección de email para completar el registro
-    MSG
-  end
-
-  it 'autofills username when facebook account has no email' do
-    login_via_facebook(name: 'pepe')
-
-    assert page.has_selector?('input[value=pepe]')
-  end
-
-  it 'finishes registration when facebook account has no email' do
-    register_through_facebook_when_missing_email('pepe')
-
-    assert_content <<~TEXT
-      Se ha enviado un mensaje con un enlace de confirmación a tu correo
-      electrónico.
-    TEXT
-  end
-
-  it 'allows overriding facebook name when facebook account has no email' do
-    register_through_facebook_when_missing_email('pepe', 'pepito')
-
-    assert_equal ['pepito'], User.pluck(:username)
-  end
-
-  it 'requires user to confirm email when facebook account has no email' do
-    register_through_facebook_when_missing_email('pepe')
-    login_via_facebook(name: 'pepe')
-
-    assert_content 'Tienes que confirmar tu cuenta para poder continuar'
-  end
-
-  it 'logs user in after confirming email when facebook account has no email' do
-    register_through_facebook_when_missing_email('pepe')
-    User.first.confirm
-    login_via_facebook(name: 'pepe')
-
-    assert_content 'hola, pepe'
-  end
-
   it 'succesfully links to old user if email already present in db' do
     user = create(:user, username: 'pepito', email: 'pepe@facebook.com')
     mocking_yahoo_woeid_info(user.woeid) do
@@ -63,14 +19,5 @@ class FacebookRegistrationTest < ActionDispatch::IntegrationTest
     end
 
     assert_content 'hola, pepito'
-  end
-
-  private
-
-  def register_through_facebook_when_missing_email(facebook_name, name = nil)
-    login_via_facebook(name: facebook_name)
-    fill_in 'Tu email', with: "#{facebook_name}@example.com"
-    fill_in 'Elige un nombre de usuario', with: name if name
-    click_button 'Regístrate'
   end
 end

--- a/test/integration/facebook_registration_test.rb
+++ b/test/integration/facebook_registration_test.rb
@@ -9,7 +9,7 @@ class FacebookRegistrationTest < ActionDispatch::IntegrationTest
   it 'properly authenticates user when facebook account has an email' do
     login_via_facebook(name: 'pepe', email: 'pepe@facebook.com')
 
-    assert page.has_content?('hola, pepe')
+    assert_content 'hola, pepe'
   end
 
   it 'redirects to a form when facebook account has no email' do

--- a/test/integration/facebook_registration_test.rb
+++ b/test/integration/facebook_registration_test.rb
@@ -64,7 +64,6 @@ class FacebookRegistrationTest < ActionDispatch::IntegrationTest
     end
 
     assert_content 'hola, pepito'
-    assert_equal 1, User.count
   end
 
   private

--- a/test/integration/facebook_registration_test.rb
+++ b/test/integration/facebook_registration_test.rb
@@ -29,7 +29,7 @@ class FacebookRegistrationTest < ActionDispatch::IntegrationTest
   it 'finishes registration when facebook account has no email' do
     register_through_facebook_when_missing_email('pepe')
 
-    assert_content <<-TEXT
+    assert_content <<~TEXT
       Se ha enviado un mensaje con un enlace de confirmación a tu correo
       electrónico.
     TEXT

--- a/test/integration/facebook_registration_test.rb
+++ b/test/integration/facebook_registration_test.rb
@@ -38,8 +38,7 @@ class FacebookRegistrationTest < ActionDispatch::IntegrationTest
   it 'allows overriding facebook name when facebook account has no email' do
     register_through_facebook_when_missing_email('pepe', 'pepito')
 
-    assert_equal 'pepito', User.first.username
-    assert_equal 1, User.count
+    assert_equal ['pepito'], User.pluck(:username)
   end
 
   it 'requires user to confirm email when facebook account has no email' do

--- a/test/integration/facebook_registration_test.rb
+++ b/test/integration/facebook_registration_test.rb
@@ -15,8 +15,9 @@ class FacebookRegistrationTest < ActionDispatch::IntegrationTest
   it 'redirects to a form when facebook account has no email' do
     login_via_facebook(name: 'pepe')
 
-    content = 'Por favor, rellena este formulario para finalizar el registro'
-    assert_content(content)
+    assert_content <<~MSG
+      Necesitamos que indiques una dirección de email para completar el registro
+    MSG
   end
 
   it 'autofills username when facebook account has no email' do

--- a/test/integration/facebook_registration_test.rb
+++ b/test/integration/facebook_registration_test.rb
@@ -29,12 +29,10 @@ class FacebookRegistrationTest < ActionDispatch::IntegrationTest
   it 'finishes registration when facebook account has no email' do
     register_through_facebook_when_missing_email('pepe')
 
-    msg = <<-TEXT
+    assert_content <<-TEXT
       Se ha enviado un mensaje con un enlace de confirmación a tu correo
       electrónico.
     TEXT
-
-    assert_content msg
   end
 
   it 'allows overriding facebook name when facebook account has no email' do

--- a/test/integration/links_for_available_ads_test.rb
+++ b/test/integration/links_for_available_ads_test.rb
@@ -13,7 +13,7 @@ class LinksForAvailableAdsTest < ActionDispatch::IntegrationTest
     mocking_yahoo_woeid_info(@woeid_code) do
       visit ads_woeid_path(id: @woeid_code, type: 'give', status: 'available')
 
-      assert page.has_content?('Envía un mensaje privado al anunciante')
+      assert_content 'Envía un mensaje privado al anunciante'
     end
   end
 
@@ -21,7 +21,7 @@ class LinksForAvailableAdsTest < ActionDispatch::IntegrationTest
     mocking_yahoo_woeid_info(@woeid_code) do
       visit ad_path(@ad)
 
-      assert page.has_content?('Envía un mensaje privado al anunciante')
+      assert_content 'Envía un mensaje privado al anunciante'
     end
   end
 
@@ -29,7 +29,7 @@ class LinksForAvailableAdsTest < ActionDispatch::IntegrationTest
     mocking_yahoo_woeid_info(@woeid_code) do
       visit ad_path(@ad)
 
-      assert page.has_content?('accede para escribir un comentario')
+      assert_content 'accede para escribir un comentario'
     end
   end
 end

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+require 'support/web_mocking'
+
+class PasswordResetTest < ActionDispatch::IntegrationTest
+  include WebMocking
+
+  before { @user = create(:user, email: 'nolotiro@example.com') }
+
+  it 'sends a confirmation email' do
+    visit root_path
+    click_link 'acceder'
+    click_link '¿Has olvidado tu contraseña?'
+    fill_in 'Correo electrónico', with: 'nolotiro@example.com'
+    click_button 'Enviar por correo'
+
+    assert_content <<~MSG
+      Vas a recibir un correo con instrucciones sobre cómo resetear tu
+      contraseña en unos pocos minutos.
+    MSG
+  end
+
+  it 'changes password and logs user in' do
+    mocking_yahoo_woeid_info(@user.woeid) do
+      token = @user.send_reset_password_instructions
+      visit edit_user_password_path(reset_password_token: token)
+
+      fill_in 'Contraseña nueva', with: '222222'
+      fill_in 'Contraseña nueva (repetir)', with: '222222'
+      click_button 'Cambiar contraseña'
+
+      assert_content 'Tu contraseña fue cambiada. Ya iniciaste sesión.'
+    end
+  end
+end

--- a/test/integration/registration_test.rb
+++ b/test/integration/registration_test.rb
@@ -21,13 +21,13 @@ class RegistrationTest < ActionDispatch::IntegrationTest
       electrónico.
     TEXT
 
-    assert page.has_content?(msg)
+    assert_content msg
   end
 
   it 'redirects to change city page after first login' do
     User.first.confirm
     login('nolotiro@example.com', '111111')
 
-    assert page.has_content?('Cambia tu ciudad')
+    assert_content 'Cambia tu ciudad'
   end
 end

--- a/test/integration/registration_test.rb
+++ b/test/integration/registration_test.rb
@@ -16,10 +16,10 @@ class RegistrationTest < ActionDispatch::IntegrationTest
   end
 
   it 'sends a confirmation email' do
-    assert_content <<~TEXT
+    assert_content <<~MSG
       Se ha enviado un mensaje con un enlace de confirmación a tu correo
       electrónico.
-    TEXT
+    MSG
   end
 
   it 'redirects to change city page after first login' do

--- a/test/integration/registration_test.rb
+++ b/test/integration/registration_test.rb
@@ -16,12 +16,10 @@ class RegistrationTest < ActionDispatch::IntegrationTest
   end
 
   it 'sends a confirmation email' do
-    msg = <<-TEXT
+    assert_content <<-TEXT
       Se ha enviado un mensaje con un enlace de confirmación a tu correo
       electrónico.
     TEXT
-
-    assert_content msg
   end
 
   it 'redirects to change city page after first login' do

--- a/test/integration/registration_test.rb
+++ b/test/integration/registration_test.rb
@@ -16,7 +16,7 @@ class RegistrationTest < ActionDispatch::IntegrationTest
   end
 
   it 'sends a confirmation email' do
-    assert_content <<-TEXT
+    assert_content <<~TEXT
       Se ha enviado un mensaje con un enlace de confirmación a tu correo
       electrónico.
     TEXT


### PR DESCRIPTION
Fixes #320 y los errores en errbit: https://err.nolotiro.org/apps/571de5807a440000b2000005/problems/57620c149b4cb1011e000001

La idea es dar la oportunidad a la usuaria de "arreglar" su registro, ya sea eligiendo un nuevo username o bien iniciando sesión con el otro usuario que registró. Para ello proveemos un formulario y un mensaje de error lo más claro posible.