### PR TITLE
Responsive messages issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ group :test do
   gem 'vcr', '~> 3.0'
   gem 'webmock', '~> 2.0'
   gem 'database_cleaner', '~> 1.5'
+  gem 'poltergeist'
+  gem 'phantomjs'
 end
 
 group :production, :staging do 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,7 +405,7 @@ GEM
     slim (3.0.6)
       temple (~> 0.7.3)
       tilt (>= 1.3.3, < 2.1)
-    spring (1.7.1)
+    spring (1.7.2)
     sprockets (3.6.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,7 @@ GEM
       mimemagic (>= 0.3.0)
     climate_control (0.0.3)
       activesupport (>= 3.0)
+    cliver (0.3.2)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
     coffee-rails (4.0.1)
@@ -302,7 +303,13 @@ GEM
       cocaine (~> 0.5.5)
       mime-types
       mimemagic (= 0.3.0)
+    phantomjs (2.1.1.0)
     pkg-config (1.1.7)
+    poltergeist (1.9.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     polyamorous (1.3.0)
       activerecord (>= 3.0)
     rack (1.6.4)
@@ -459,6 +466,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    websocket-driver (0.6.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     will_paginate (3.1.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -509,6 +519,8 @@ DEPENDENCIES
   omniauth-facebook
   omniauth-google-oauth2
   paperclip (~> 4.0)
+  phantomjs
+  poltergeist
   rails (~> 4.2)
   rails-i18n (~> 4.0)
   rakismet

--- a/app/assets/stylesheets/_common.sass.erb
+++ b/app/assets/stylesheets/_common.sass.erb
@@ -275,7 +275,6 @@ form.searchbox
 .message-excerpt
   width: 100%
   display: block
-  float: left
   margin-bottom: 20px
   position: relative
 

--- a/test/integration/concerns/messages.rb
+++ b/test/integration/concerns/messages.rb
@@ -1,10 +1,11 @@
-require "test_helper"
 require "integration/concerns/authentication"
 
-class MessagesTest < ActionDispatch::IntegrationTest
+module Messages
   include Warden::Test::Helpers
 
-  before do
+  def setup
+    super
+
     user1 = FactoryGirl.create(:user, username: 'user1')
     @user2 = FactoryGirl.create(:user, username: 'user2')
 
@@ -13,40 +14,40 @@ class MessagesTest < ActionDispatch::IntegrationTest
     visit message_new_path(@user2)
   end
 
-  it 'shows errors when message has no subject' do
+  def test_shows_errors_when_message_has_no_subject
     send_message(body: 'hola, user2')
 
     assert_content('Título no puede estar en blanco')
   end
 
-  it 'prevents from creating conversation with empty message' do
+  def test_prevents_from_creating_conversation_with_empty_message
     send_message(subject: 'hola, user2')
 
     assert_content('Nuevo mensaje privado para el usuario user2')
   end
 
-  it 'shows errors when replying to conversation with empty message' do
+  def test_shows_errors_when_replying_to_conversation_with_empty_message
     send_message(subject: 'hola, user2', body: 'How you doing?')
     send_message(body: '')
 
     assert_content('Mensaje no puede estar en blanco')
   end
 
-  it 'sends a new message after a previous error' do
+  def test_sends_a_new_message_after_a_previous_error
     send_message(body: 'hola, user2')
     send_message(subject: 'forgot the title', body: 'hola, user2')
 
     assert_content('Conversación con user2 asunto forgot the title')
   end
 
-  it 'replies to conversation' do
+  def test_replies_to_conversation
     send_message(subject: 'hola, user2', body: 'How you doing?')
     send_message(body: 'hola, user1, nice to see you around')
 
     page.assert_selector '.bubble', text: 'nice to see you around'
   end
 
-  it 'replies to conversation after a previous error' do
+  def test_replies_to_conversation_after_a_previous_error
     send_message(subject: 'hola, user2', body: 'How you doing?')
     send_message(body: '')
     send_message(body: 'forgot to reply something')
@@ -54,7 +55,7 @@ class MessagesTest < ActionDispatch::IntegrationTest
     page.assert_selector '.bubble', text: 'forgot to reply something'
   end
 
-  it 'shows the other user in the conversation header' do
+  def test_shows_the_other_user_in_the_conversation_header
     send_message(subject: 'Cosas', body: 'hola, user2')
     assert_content('Conversación con user2')
 
@@ -64,14 +65,14 @@ class MessagesTest < ActionDispatch::IntegrationTest
     assert_content('Conversación con user1')
   end
 
-  it 'links to the other user in the conversation list' do
+  def test_links_to_the_other_user_in_the_conversation_list
     send_message(subject: 'Cosas', body: 'hola, user2')
     visit messages_list_path(box: 'sent')
 
     assert page.has_link?('user2'), 'No link to "user2" found'
   end
 
-  it 'just shows a special label when the interlocutor is no longer there' do
+  def test_just_shows_a_special_label_when_the_interlocutor_is_no_longer_there
     send_message(subject: 'Cosas', body: 'hola, user2')
     @user2.destroy
     visit messages_list_path(box: 'sent')
@@ -80,14 +81,14 @@ class MessagesTest < ActionDispatch::IntegrationTest
     refute page.has_link?('[borrado]')
   end
 
-  it "messages another user" do
+  def test_messages_another_user
     send_message(subject: "hola mundo", body: "hola trololo")
 
     assert_content("hola trololo")
     assert_content("Mover mensaje a papelera")
   end
 
-  it "messages another user using emojis" do
+  def test_messages_another_user_using_emojis
     skip "emojis not supported"
     send_message(subject: "hola mundo", body: "What a nice emoji😀!")
 
@@ -95,7 +96,7 @@ class MessagesTest < ActionDispatch::IntegrationTest
     assert_content("Mover mensaje a papelera")
   end
 
-  it "replies to a message" do
+  def test_replies_to_a_message
     send_message(subject: "hola mundo", body: "hola trololo")
     send_message(body: "hola trululu")
 
@@ -112,4 +113,3 @@ class MessagesTest < ActionDispatch::IntegrationTest
     click_button "Enviar"
   end
 end
-

--- a/test/integration/desktop_messages_test.rb
+++ b/test/integration/desktop_messages_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+require "support/desktop_integration"
+require "integration/concerns/messages"
+
+class DesktopMessagesTest < DesktopIntegrationTest
+  include Messages
+end

--- a/test/integration/messages_test.rb
+++ b/test/integration/messages_test.rb
@@ -19,10 +19,10 @@ class MessagesTest < ActionDispatch::IntegrationTest
     assert_content('Título no puede estar en blanco')
   end
 
-  it 'shows errors when creating conversation with empty message' do
+  it 'prevents from creating conversation with empty message' do
     send_message(subject: 'hola, user2')
 
-    assert_content('Mensaje no puede estar en blanco')
+    assert_content('Nuevo mensaje privado para el usuario user2')
   end
 
   it 'shows errors when replying to conversation with empty message' do

--- a/test/integration/mobile_messages_test.rb
+++ b/test/integration/mobile_messages_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+require "support/mobile_integration"
+require "integration/concerns/messages"
+
+class MobileMessagesTest < MobileIntegrationTest
+  include Messages
+end

--- a/test/support/desktop_integration.rb
+++ b/test/support/desktop_integration.rb
@@ -1,0 +1,15 @@
+require 'phantomjs'
+
+Capybara.register_driver :poltergeist_desktop do |app|
+  Capybara::Poltergeist::Driver.new(app, window_size: [1366, 768],
+                                         phantomjs: Phantomjs.path)
+end
+
+class DesktopIntegrationTest < ActionDispatch::IntegrationTest
+  before do
+    Capybara.javascript_driver = :poltergeist_desktop
+    Capybara.current_driver = Capybara.javascript_driver
+  end
+
+  after { Capybara.current_driver = Capybara.default_driver }
+end

--- a/test/support/integration.rb
+++ b/test/support/integration.rb
@@ -1,3 +1,8 @@
+require 'phantomjs/poltergeist'
+require 'capybara/poltergeist'
+require 'support/desktop_integration'
+require 'support/mobile_integration'
+
 module ActionDispatch
   #
   # Base class for integration tests

--- a/test/support/mobile_integration.rb
+++ b/test/support/mobile_integration.rb
@@ -1,0 +1,15 @@
+require 'phantomjs'
+
+Capybara.register_driver :poltergeist_mobile do |app|
+  Capybara::Poltergeist::Driver.new(app, window_size: [320, 480],
+                                         phantomjs: Phantomjs.path)
+end
+
+class MobileIntegrationTest < ActionDispatch::IntegrationTest
+  before do
+    Capybara.javascript_driver = :poltergeist_mobile
+    Capybara.current_driver = Capybara.javascript_driver
+  end
+
+  after { Capybara.current_driver = Capybara.default_driver }
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,7 @@ require 'vcr'
 VCR.configure do |config|
   config.cassette_library_dir = 'test/fixtures/vcr_cassettes'
   config.hook_into :webmock
+  config.ignore_localhost = true
 end
 
 # Configure database cleaning


### PR DESCRIPTION
Una usuaria ha reportado que no puede responder a mensajes desde el móvil. Y efectivamente, tanto nosotros como los tests no detectaron esto cuando hicimos la migración a bootstrap (supongo).

He añadido un poco de maquinaria para poder correr los tests contra distintas resoluciones de pantalla y poder detectar este tipo de cosas en el futuro.