### PR TITLE
Reenable page level ads

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,6 +48,12 @@
 
     <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 
+    <script>
+      (adsbygoogle = window.adsbygoogle || []).push({
+        google_ad_client: "ca-pub-5360961269901609",
+        enable_page_level_ads: true
+      });
+    </script>
   </head>
   <body>
 


### PR DESCRIPTION
Eliminé esto de forma errónea y creo que podría explicar la caída en la performance de adsense.