### PR TITLE
Segundo refactoring pre-bloqueos

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -34,9 +34,9 @@ class ConversationsController < ApplicationController
   end
 
   def update
-    @message = Mailboxer::Message.new message_params
+    @conversation = conversations.find(params[:id])
 
-    @conversation = conversations.find(@message.conversation_id)
+    @message = @conversation.messages.build message_params
 
     return render_show_with(interlocutor(@conversation)) unless @message.valid?
 
@@ -67,7 +67,7 @@ class ConversationsController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def message_params
     params.require(:mailboxer_message)
-          .permit(:conversation_id, :body, :subject, :recipients)
+          .permit(:body, :subject, :recipients)
           .merge(sender: current_user)
   end
 

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -17,7 +17,7 @@ class ConversationsController < ApplicationController
   def new
     @message = Mailboxer::Message.new
     @recipient = User.find(params[:user_id])
-    @message.recipients = @recipient.id if params[:user_id]
+    @message.recipients = @recipient.id
   end
 
   def create

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -22,7 +22,6 @@ class ConversationsController < ApplicationController
 
   def create
     initialize_message
-    return if performed?
 
     recipient = User.find(recipient_id)
     receipt = current_user.send_message([recipient], @message.body, @message.subject)
@@ -36,7 +35,6 @@ class ConversationsController < ApplicationController
 
   def update
     initialize_message
-    return if performed?
 
     @conversation = conversations.find(@message.conversation_id)
 
@@ -78,11 +76,6 @@ class ConversationsController < ApplicationController
   def initialize_message
     @message = Mailboxer::Message.new message_params
     @message.sender = current_user
-    # FIXME: this should be on model (validation)
-    return unless current_user.id == recipient_id
-
-    redirect_to message_new_path(user_id: recipient_id),
-                notice: I18n.t('mailboxer.notifications.error_same_user')
   end
 
   def render_show_with(recipient)

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -66,7 +66,7 @@ class ConversationsController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def message_params
-    params.require(:mailboxer_message).permit(:conversation_id, :body, :subject, :recipients, :sender_id)
+    params.require(:mailboxer_message).permit(:conversation_id, :body, :subject, :recipients)
   end
 
   def recipient_id

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -21,7 +21,7 @@ class ConversationsController < ApplicationController
   end
 
   def create
-    initialize_message
+    @message = Mailboxer::Message.new message_params
 
     recipient = User.find(recipient_id)
     receipt = current_user.send_message([recipient], @message.body, @message.subject)
@@ -34,7 +34,7 @@ class ConversationsController < ApplicationController
   end
 
   def update
-    initialize_message
+    @message = Mailboxer::Message.new message_params
 
     @conversation = conversations.find(@message.conversation_id)
 
@@ -66,16 +66,13 @@ class ConversationsController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def message_params
-    params.require(:mailboxer_message).permit(:conversation_id, :body, :subject, :recipients)
+    params.require(:mailboxer_message)
+          .permit(:conversation_id, :body, :subject, :recipients)
+          .merge(sender: current_user)
   end
 
   def recipient_id
     params[:mailboxer_message][:recipients].to_i
-  end
-
-  def initialize_message
-    @message = Mailboxer::Message.new message_params
-    @message.sender = current_user
   end
 
   def render_show_with(recipient)

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -52,7 +52,7 @@ class ConversationsController < ApplicationController
     @conversation = conversations.find(params[:id])
     @interlocutor = interlocutor(@conversation)
 
-    @message = Mailboxer::Message.new conversation_id: @conversation.id
+    @message = Mailboxer::Message.new conversation: @conversation
     current_user.mark_as_read(@conversation)
   end
 

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -79,7 +79,7 @@ class ConversationsController < ApplicationController
     @message = Mailboxer::Message.new message_params
     @message.sender = current_user
     # FIXME: this should be on model (validation)
-    return unless @message.sender.id == recipient_id
+    return unless current_user.id == recipient_id
 
     redirect_to message_new_path(user_id: recipient_id),
                 notice: I18n.t('mailboxer.notifications.error_same_user')

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -15,9 +15,8 @@ class ConversationsController < ApplicationController
   end
 
   def new
-    @message = Mailboxer::Message.new
     @recipient = User.find(params[:user_id])
-    @message.recipients = @recipient.id
+    @message = Mailboxer::Message.new(recipients: @recipient.id)
   end
 
   def create

--- a/app/helpers/message_helper.rb
+++ b/app/helpers/message_helper.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 module MessageHelper
-  def interlocutor_username(c)
-    other_user = interlocutor(c)
-
-    other_user ? other_user.username : '[borrado]'
+  def interlocutor_username
+    @interlocutor ? @interlocutor.username : '[borrado]'
   end
 
   def link_to_interlocutor(c)

--- a/app/views/conversations/_reply.html.haml
+++ b/app/views/conversations/_reply.html.haml
@@ -10,7 +10,7 @@
         = form_for message,
                    url: mailboxer_conversation_path(message.conversation),
                    method: :put do |f|
-          = errors_for(@message)
+          = errors_for(message)
           = f.hidden_field :conversation_id
           = f.text_area :body, size: '80x3', maxlength: 1500
           %p.description

--- a/app/views/conversations/_reply.html.haml
+++ b/app/views/conversations/_reply.html.haml
@@ -11,7 +11,6 @@
                    url: mailboxer_conversation_path(message.conversation),
                    method: :put do |f|
           = errors_for(message)
-          = f.hidden_field :conversation_id
           = f.text_area :body, size: '80x3', maxlength: 1500
           %p.description
             = t 'mailboxer.new.body_max'

--- a/app/views/conversations/new.html.haml
+++ b/app/views/conversations/new.html.haml
@@ -1,4 +1,4 @@
-- title = t('mailboxer.new.title', user: @recipient.username)
+- title = t('mailboxer.new.title', user: @interlocutor.username)
 - content_for :meta_title, title
 
 #default_header_section

--- a/app/views/conversations/show.html.haml
+++ b/app/views/conversations/show.html.haml
@@ -1,4 +1,4 @@
-- title = t("mailboxer.titles.conversation", recipient: interlocutor_username(@conversation),
+- title = t("mailboxer.titles.conversation", recipient: interlocutor_username,
                                              subject: @conversation.subject)
 - content_for :meta_title, title
 

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -229,7 +229,6 @@ ca:
       you_have_new_reply: Has rebut una nova resposta
       you_have_recieved_new_reply: Has rebut una nova resposta
     notifications:
-      error_same_user: No pots enviar-me un missatge a tu mateix
       sent: missatge enviat
       trash: Missatge esborrat
     search: Resultats de cerca de %{search}

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -201,8 +201,8 @@ ca:
   mailboxer:
     buttons:
       back: "<Tornar a missatges"
-      trash: Esborrar missatge
-      trash_selected: Esborrar missatges seleccionats
+      trash: Esborrar conversa
+      trash_selected: Esborrar converses seleccionats
     message_mailer:
       message:
         body: missatge
@@ -230,7 +230,7 @@ ca:
       you_have_recieved_new_reply: Has rebut una nova resposta
     notifications:
       sent: missatge enviat
-      trash: Missatge esborrat
+      trash: Conversa esborrat
     search: Resultats de cerca de %{search}
     table:
       date: Fecha

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -201,8 +201,8 @@ ca:
   mailboxer:
     buttons:
       back: "<Tornar a missatges"
-      trash: Esborrar conversa
-      trash_selected: Esborrar converses seleccionats
+      trash: Arxivar conversa
+      trash_selected: Arxivar converses seleccionats
     message_mailer:
       message:
         body: missatge
@@ -230,7 +230,7 @@ ca:
       you_have_recieved_new_reply: Has rebut una nova resposta
     notifications:
       sent: missatge enviat
-      trash: Conversa esborrat
+      trash: Conversa arxivada
     search: Resultats de cerca de %{search}
     table:
       date: Fecha

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -229,7 +229,6 @@ de:
       you_have_new_reply: 
       you_have_recieved_new_reply: 
     notifications:
-      error_same_user: 
       sent: 
       trash: 
     search: 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,8 +197,8 @@ en:
   mailboxer:
     buttons:
       back: "< back to messages"
-      trash: Delete message
-      trash_selected: Delete selected messages
+      trash: Delete conversation
+      trash_selected: Delete selected conversations
     message_mailer:
       message:
         body: Message
@@ -226,7 +226,7 @@ en:
       you_have_recieved_new_reply: You have a new answer
     notifications:
       sent: Sent message
-      trash: Message deleted
+      trash: Conversation deleted
     search: Search results %{search}
     table:
       date: Date

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -225,7 +225,6 @@ en:
       you_have_new_reply: You have a new answer
       you_have_recieved_new_reply: You have a new answer
     notifications:
-      error_same_user: You can not send a message to yourself
       sent: Sent message
       trash: Message deleted
     search: Search results %{search}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,8 +197,8 @@ en:
   mailboxer:
     buttons:
       back: "< back to messages"
-      trash: Delete conversation
-      trash_selected: Delete selected conversations
+      trash: Archive conversation
+      trash_selected: Archive selected conversations
     message_mailer:
       message:
         body: Message
@@ -226,7 +226,7 @@ en:
       you_have_recieved_new_reply: You have a new answer
     notifications:
       sent: Sent message
-      trash: Conversation deleted
+      trash: Conversation archived
     search: Search results %{search}
     table:
       date: Date

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -201,8 +201,8 @@ es:
   mailboxer:
     buttons:
       back: "< volver a mensajes"
-      trash: Borrar conversación
-      trash_selected: Borrar conversaciones seleccionadas
+      trash: Archivar conversación
+      trash_selected: Archivar conversaciones seleccionadas
     message_mailer:
       message:
         body: Mensaje
@@ -230,7 +230,7 @@ es:
       you_have_recieved_new_reply: Has recibido una nueva respuesta
     notifications:
       sent: Mensaje enviado
-      trash: Conversación borrada
+      trash: Conversación archivada
     search: Resultados de busqueda de %{search}
     table:
       date: Fecha

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -229,7 +229,6 @@ es:
       you_have_new_reply: Has recibido una nueva respuesta
       you_have_recieved_new_reply: Has recibido una nueva respuesta
     notifications:
-      error_same_user: No puedes enviarte un mensaje a tí mismo
       sent: Mensaje enviado
       trash: Mensaje borrado
     search: Resultados de busqueda de %{search}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -201,8 +201,8 @@ es:
   mailboxer:
     buttons:
       back: "< volver a mensajes"
-      trash: Borrar mensaje
-      trash_selected: Borrar mensajes seleccionados
+      trash: Borrar conversación
+      trash_selected: Borrar conversaciones seleccionadas
     message_mailer:
       message:
         body: Mensaje
@@ -230,7 +230,7 @@ es:
       you_have_recieved_new_reply: Has recibido una nueva respuesta
     notifications:
       sent: Mensaje enviado
-      trash: Mensaje borrado
+      trash: Conversación borrada
     search: Resultados de busqueda de %{search}
     table:
       date: Fecha

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -229,7 +229,6 @@ eu:
       you_have_new_reply: 
       you_have_recieved_new_reply: 
     notifications:
-      error_same_user: 
       sent: 
       trash: 
     search: 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -231,7 +231,6 @@ fr:
       you_have_new_reply: 
       you_have_recieved_new_reply: 
     notifications:
-      error_same_user: 
       sent: 
       trash: 
     search: 

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -240,7 +240,6 @@ gl:
       you_have_new_reply: Recibiu unha nova resposta
       you_have_recieved_new_reply: Recibiu unha nova resposta
     notifications:
-      error_same_user: Non pode enviar unha mensaxe a si mesmo
       sent: 
       trash: 
     search: 

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -241,7 +241,7 @@ gl:
       you_have_recieved_new_reply: Recibiu unha nova resposta
     notifications:
       sent: 
-      trash: 
+      trash: Conversa arquivada
     search: 
     table:
       date: Data

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -208,8 +208,8 @@ gl:
   mailboxer:
     buttons:
       back: 
-      trash: Eliminar conversa
-      trash_selected: Eliminar conversas seleccionadas
+      trash: Arquivar conversa
+      trash_selected: Arquivar conversas seleccionadas
     message_mailer:
       message:
         body: Mensaxe

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -208,8 +208,8 @@ gl:
   mailboxer:
     buttons:
       back: 
-      trash: Eliminar mensaxe
-      trash_selected: Eliminar mensaxes seleccionados
+      trash: Eliminar conversa
+      trash_selected: Eliminar conversas seleccionadas
     message_mailer:
       message:
         body: Mensaxe

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -229,7 +229,6 @@ it:
       you_have_new_reply: Hai ricevuto una nuova risposta
       you_have_recieved_new_reply: Hai ricevuto una nuova risposta
     notifications:
-      error_same_user: No puoi inviare un messaggio a te stesso
       sent: Messaggio inviato
       trash: Messaggio cancellato
     search: Risultati della ricerca su %{search}

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -201,8 +201,8 @@ it:
   mailboxer:
     buttons:
       back: "< torna al messaggio"
-      trash: Cancellare il messaggio
-      trash_selected: Cancellare i messaggi selezionati
+      trash: Cancellare la conversazione
+      trash_selected: Cancellare le conversazioni selezionati
     message_mailer:
       message:
         body: Messaggio
@@ -230,7 +230,7 @@ it:
       you_have_recieved_new_reply: Hai ricevuto una nuova risposta
     notifications:
       sent: Messaggio inviato
-      trash: Messaggio cancellato
+      trash: Conversazione cancellata
     search: Risultati della ricerca su %{search}
     table:
       date: Data

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -201,8 +201,8 @@ it:
   mailboxer:
     buttons:
       back: "< torna al messaggio"
-      trash: Cancellare la conversazione
-      trash_selected: Cancellare le conversazioni selezionati
+      trash: Archiviare la conversazione
+      trash_selected: Archiviare le conversazioni selezionati
     message_mailer:
       message:
         body: Messaggio
@@ -230,7 +230,7 @@ it:
       you_have_recieved_new_reply: Hai ricevuto una nuova risposta
     notifications:
       sent: Messaggio inviato
-      trash: Conversazione cancellata
+      trash: Conversazione archiviata
     search: Risultati della ricerca su %{search}
     table:
       date: Data

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -219,7 +219,6 @@ nl:
       you_have_new_reply: 
       you_have_recieved_new_reply: 
     notifications:
-      error_same_user: 
       sent: 
       trash: 
     search: 

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -229,7 +229,6 @@ pt:
       you_have_new_reply: Você têm uma nova resposta
       you_have_recieved_new_reply: Você têm uma nova resposta
     notifications:
-      error_same_user: Você não pode enviar uma mensagem para você mesmo
       sent: Mensagem enviada
       trash: Mensagem apagada
     search: Resultados da busca de %{search}

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -201,8 +201,8 @@ pt:
   mailboxer:
     buttons:
       back: "< voltar a mensagens"
-      trash: Apagar conversa
-      trash_selected: Apagar conversas selecionadas
+      trash: Arquivar conversa
+      trash_selected: Arquivar conversas selecionadas
     message_mailer:
       message:
         body: Mensagem
@@ -230,7 +230,7 @@ pt:
       you_have_recieved_new_reply: Você têm uma nova resposta
     notifications:
       sent: Mensagem enviada
-      trash: Conversa apagada
+      trash: Conversa arquivada
     search: Resultados da busca de %{search}
     table:
       date: Data

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -201,8 +201,8 @@ pt:
   mailboxer:
     buttons:
       back: "< voltar a mensagens"
-      trash: Apagar mensagem
-      trash_selected: Apagar mensagens selecionados
+      trash: Apagar conversa
+      trash_selected: Apagar conversas selecionadas
     message_mailer:
       message:
         body: Mensagem
@@ -230,7 +230,7 @@ pt:
       you_have_recieved_new_reply: Você têm uma nova resposta
     notifications:
       sent: Mensagem enviada
-      trash: Mensagem apagada
+      trash: Conversa apagada
     search: Resultados da busca de %{search}
     table:
       date: Data

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,7 +95,6 @@ NolotiroOrg::Application.routes.draw do
     # messaging legacy
     scope '/message' do
       get  '/list', to: 'conversations#index', as: 'messages_list'
-      get  '/show/:id/subject/:subject', to: 'conversations#show', as: 'message_show'
       get  '/create/id_user_to/:user_id', to: 'conversations#new', as: 'message_new'
       get  '/create/id_user_to/:user_id/subject/:subject', to: 'conversations#new', as: 'message_new_with_subject'
       post '/create/id_user_to/:user_id', to: 'conversations#update'

--- a/test/integration/concerns/messages.rb
+++ b/test/integration/concerns/messages.rb
@@ -88,7 +88,7 @@ module Messages
     assert_message_sent 'hola trololo'
   end
 
-  def test_deletes_a_single_message_and_shows_an_confirmation_flash
+  def test_deletes_a_single_conversation_and_shows_an_confirmation_flash
     send_message(subject: 'hola mundo', body: 'What a nice message!')
     click_link 'Borrar mensaje'
 
@@ -96,7 +96,7 @@ module Messages
     assert_content 'Mensaje borrado'
   end
 
-  def test_deletes_multiple_messages_by_checkbox
+  def test_deletes_multiple_conversations_by_checkbox
     send_message(subject: 'hola mundo', body: 'What a nice message!')
     visit message_new_path(@user2)
     send_message(subject: 'hola marte', body: 'What a nice message!')

--- a/test/integration/concerns/messages.rb
+++ b/test/integration/concerns/messages.rb
@@ -103,7 +103,6 @@ module Messages
 
     visit messages_list_path
     check("delete-conversation-#{Mailboxer::Conversation.first.id}")
-    dismiss_cookie_bar
     click_button 'Borrar mensajes seleccionados'
 
     refute_content 'hola mundo'
@@ -115,14 +114,6 @@ module Messages
   def assert_message_sent(text)
     assert_css_selector '.bubble', text: text
     assert_content 'Mensaje enviado'
-  end
-
-  #
-  # Sometimes cookie bar gets in the middle of our tests.
-  # Just dismiss the alert for now.
-  #
-  def dismiss_cookie_bar
-    within('#cookie-bar') { click_link 'OK' }
   end
 
   def send_message(params)

--- a/test/integration/concerns/messages.rb
+++ b/test/integration/concerns/messages.rb
@@ -86,7 +86,6 @@ module Messages
     send_message(subject: 'hola mundo', body: 'hola trololo')
 
     assert_message_sent 'hola trololo'
-    assert_content 'Borrar mensaje'
   end
 
   def test_deletes_a_single_message_and_shows_an_confirmation_flash

--- a/test/integration/concerns/messages.rb
+++ b/test/integration/concerns/messages.rb
@@ -7,10 +7,10 @@ module Messages
   def setup
     super
 
-    user1 = FactoryGirl.create(:user, username: 'user1')
+    @user1 = FactoryGirl.create(:user, username: 'user1')
     @user2 = FactoryGirl.create(:user, username: 'user2')
 
-    login_as user1
+    login_as @user1
 
     visit message_new_path(@user2)
   end
@@ -107,6 +107,20 @@ module Messages
 
     refute_content 'hola mundo'
     assert_content 'hola marte'
+  end
+
+  def revives_deleted_conversation_when_the_other_user_replies_again
+    send_message(subject: 'hola mundo', body: 'What a nice message!')
+    click_link 'Borrar mensaje'
+    refute_content 'hola mundo'
+
+    login_as @user2
+    visit mailboxer_conversation_path(Mailboxer::Conversation.first)
+    send_message(body: 'hombre, tú por aquí')
+
+    login_as @user1
+    visit messages_list_path
+    assert_content 'hola mundo'
   end
 
   private

--- a/test/integration/concerns/messages.rb
+++ b/test/integration/concerns/messages.rb
@@ -88,7 +88,7 @@ module Messages
     assert_message_sent 'hola trololo'
   end
 
-  def test_deletes_a_single_conversation_and_shows_an_confirmation_flash
+  def test_deletes_a_single_conversation_and_shows_a_confirmation_flash
     send_message(subject: 'hola mundo', body: 'What a nice message!')
     click_link 'Borrar mensaje'
 

--- a/test/integration/concerns/messages.rb
+++ b/test/integration/concerns/messages.rb
@@ -90,10 +90,10 @@ module Messages
 
   def test_deletes_a_single_conversation_and_shows_a_confirmation_flash
     send_message(subject: 'hola mundo', body: 'What a nice message!')
-    click_link 'Borrar conversación'
+    click_link 'Archivar conversación'
 
     refute_content 'hola mundo'
-    assert_content 'Conversación borrada'
+    assert_content 'Conversación archivada'
   end
 
   def test_deletes_multiple_conversations_by_checkbox
@@ -103,7 +103,7 @@ module Messages
 
     visit messages_list_path
     check("delete-conversation-#{Mailboxer::Conversation.first.id}")
-    click_button 'Borrar conversaciones seleccionadas'
+    click_button 'Archivar conversaciones seleccionadas'
 
     refute_content 'hola mundo'
     assert_content 'hola marte'
@@ -111,7 +111,7 @@ module Messages
 
   def revives_deleted_conversation_when_the_other_user_replies_again
     send_message(subject: 'hola mundo', body: 'What a nice message!')
-    click_link 'Borrar conversación'
+    click_link 'Archivar conversación'
     refute_content 'hola mundo'
 
     login_as @user2

--- a/test/integration/concerns/messages.rb
+++ b/test/integration/concerns/messages.rb
@@ -90,10 +90,10 @@ module Messages
 
   def test_deletes_a_single_conversation_and_shows_a_confirmation_flash
     send_message(subject: 'hola mundo', body: 'What a nice message!')
-    click_link 'Borrar mensaje'
+    click_link 'Borrar conversación'
 
     refute_content 'hola mundo'
-    assert_content 'Mensaje borrado'
+    assert_content 'Conversación borrada'
   end
 
   def test_deletes_multiple_conversations_by_checkbox
@@ -103,7 +103,7 @@ module Messages
 
     visit messages_list_path
     check("delete-conversation-#{Mailboxer::Conversation.first.id}")
-    click_button 'Borrar mensajes seleccionados'
+    click_button 'Borrar conversaciones seleccionadas'
 
     refute_content 'hola mundo'
     assert_content 'hola marte'
@@ -111,7 +111,7 @@ module Messages
 
   def revives_deleted_conversation_when_the_other_user_replies_again
     send_message(subject: 'hola mundo', body: 'What a nice message!')
-    click_link 'Borrar mensaje'
+    click_link 'Borrar conversación'
     refute_content 'hola mundo'
 
     login_as @user2

--- a/test/integration/legacy_routing_test.rb
+++ b/test/integration/legacy_routing_test.rb
@@ -84,8 +84,6 @@ class LegacyRoutingTest < ActionDispatch::IntegrationTest
   end
 
   test 'should route messaging' do
-    get '/es/message/show/XXX/subject/XXX'
-    assert_redirected_to new_user_session_url
     get '/es/message/list'
     assert_redirected_to new_user_session_url
     post_via_redirect new_user_session_url, 'user[email]' => @user.email, 'user[password]' => @user.password
@@ -93,11 +91,6 @@ class LegacyRoutingTest < ActionDispatch::IntegrationTest
     assert_routing '/es/messages', controller: 'conversations',
                                    action: 'index',
                                    locale: 'es'
-    assert_routing '/es/message/show/XXX/subject/XXX', controller: 'conversations',
-                                                       action: 'show',
-                                                       locale: 'es',
-                                                       id: 'XXX',
-                                                       subject: 'XXX'
   end
 
   test 'should route auth' do


### PR DESCRIPTION
Esto me ayuda a poder implementar un sistema de autorizaciones para conversaciones y mensajes (lo que falta para implementar bloqueos).

Además, "arregla" #336 simplemente permitiendo los automensajes. Prohibirlos añade una complejidad innecesaria que no merece la pena. Telegram o whatsapp lo permiten también.

Fixes #336.

Esta finalizado, pero quiero añadir un par de cosas:

* [x] Un test de regresión para una funcionalidad que no está testeada: Cuando se borra una conversación, pero la otra usuaria contesta, la conversación debe reaparecer.
* [x] Renombrar "borrar" a "archivar" para que quede mejor con el punto anteriror.