### PR TITLE
Fix duplicated emails & usernames

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ gem 'activeadmin', github: 'activeadmin'            # admin backend
 gem 'rakismet'                                      # antispam
 gem 'font-awesome-rails'                            # font-awesome icons
 gem 'faker'
-gem 'ruby-progressbar'
+gem 'ruby-progressbar', require: false
 
 gem 'mailboxer', github: 'mailboxer'                # messaging
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,10 @@ group :doc do
   gem 'sdoc', require: false
 end
 
+group :console do
+  gem 'table_print'
+end
+
 group :development, :test do
   gem 'minitest-spec-rails'                 # test: specs style out-of-the-box
   gem 'capybara'                            # test: real user interactions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,6 +433,7 @@ GEM
     sshkit (1.11.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    table_print (1.5.6)
     temple (0.7.6)
     thin (1.5.1)
       daemons (>= 1.0.9)
@@ -538,6 +539,7 @@ DEPENDENCIES
   sinatra
   slim
   spring
+  table_print
   thinking-sphinx
   uglifier (>= 1.3.0)
   unicorn

--- a/app/choosers/duplicate_email_user_chooser.rb
+++ b/app/choosers/duplicate_email_user_chooser.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#
+# Chooses the user that will stay in DB from a series of users
+#
+class DuplicateEmailUserChooser
+  def initialize(users)
+    @users = users
+  end
+
+  def choose
+    user = last_visitor || last_publisher || last_confirmed || last_registered
+    abort unless user
+
+    user.id
+  end
+
+  private
+
+  def last_visitor
+    latest_by(:current_sign_in_at) || latest_by(:last_sign_in_at)
+  end
+
+  def last_publisher
+    @users.joins(:ads).order('ads.published_at').last
+  end
+
+  def last_confirmed
+    latest_by(:confirmed_at)
+  end
+
+  def last_registered
+    latest_by(:confirmation_sent_at)
+  end
+
+  def latest_by(column)
+    @users.where.not(column => nil).order(column => :asc).last
+  end
+end

--- a/app/choosers/duplicate_username_user_chooser.rb
+++ b/app/choosers/duplicate_username_user_chooser.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'choosers/user_chooser'
+
+#
+# Chooses a user from a series of users with duplicated usernames
+#
+class DuplicateUsernameUserChooser < UserChooser
+  def master
+    top_giver ||
+      top_taker ||
+      most_frequent_visitor ||
+      last_confirmed ||
+      last_registered
+  end
+
+  private
+
+  def top_giver
+    @users.joins(:ads)
+          .where(ads: { type: 1 })
+          .select(:user_owner, 'COUNT(*) as n_presents')
+          .group(:user_owner)
+          .having('n_presents > 0')
+          .order('n_presents DESC')
+          .first
+  end
+
+  def top_taker
+    @users.joins(:ads)
+          .where(ads: { type: 2 })
+          .select(:user_owner, 'COUNT(*) as n_requests')
+          .group(:user_owner)
+          .having('n_requests > 0')
+          .order('n_requests DESC')
+          .first
+  end
+
+  def most_frequent_visitor
+    @users.where.not(sign_in_count: 0).order(sign_in_count: :desc).first
+  end
+end

--- a/app/choosers/user_chooser.rb
+++ b/app/choosers/user_chooser.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+#
+# Chooses a user from a series of users
+#
+class UserChooser
+  def initialize(users)
+    @users = users
+  end
+
+  def master
+    raise NotImplementedError, 'Implement your criteria in the subclass'
+  end
+
+  def duplicates
+    @duplicates ||= @users.where.not(id: master.id)
+  end
+
+  private
+
+  def last_confirmed
+    latest_by(:confirmed_at)
+  end
+
+  def last_registered
+    latest_by(:confirmation_sent_at)
+  end
+
+  def latest_by(column)
+    @users.where.not(column => nil).order(column => :asc).last
+  end
+end

--- a/app/migrators/concerns/user_renamer.rb
+++ b/app/migrators/concerns/user_renamer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+#
+# Renames users with duplicated usernames
+#
+class UserRenamer
+  def initialize(user)
+    @user = user
+  end
+
+  def rename!
+    @user.update!(username: replacement)
+  end
+
+  private
+
+  def email_id
+    @email_id ||= @user.email.split('@')[0]
+  end
+
+  def replacement
+    n = 0
+
+    loop do
+      username = n == 0 ? email_id : "#{email_id}#{n}"
+      return username unless User.exists?(username: username)
+
+      n += 1
+    end
+  end
+end

--- a/app/migrators/duplicate_email_migrator.rb
+++ b/app/migrators/duplicate_email_migrator.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'ruby-progressbar'
+require 'duplicate_email_user_chooser'
+
+#
+# Migrates duplicated references to a user
+#
+class DuplicateEmailMigrator
+  def initialize(email)
+    @email = email
+  end
+
+  def self.migrate!
+    duplicated_emails = User.group('LOWER(email)')
+                            .having('COUNT(*) > 1')
+                            .pluck('LOWER(email)')
+
+    bar = ProgressBar.create(total: duplicated_emails.size,
+                             format: '%a %B %c/%C')
+
+    duplicated_emails.each do |email|
+      new(email).migrate!
+
+      bar.increment
+    end
+  end
+
+  def migrate!
+    update_references
+
+    User.where(id: duplicate_ids).destroy_all
+
+    User.find(chosen_id).update(email: @email.downcase)
+  end
+
+  private
+
+  def users
+    @users ||= User.where("LOWER(email) = '#{@email}'")
+  end
+
+  def chosen_id
+    @chosen_id ||= DuplicateEmailUserChooser.new(users).choose
+  end
+
+  def duplicate_ids
+    @duplicate_ids ||= users.where.not(id: chosen_id).pluck(:id)
+  end
+
+  def update_references
+    update_reference(Ad, :user_owner)
+    update_reference(Comment, :user_owner)
+    update_reference(Friendship, :user_id)
+    update_reference(Friendship, :friend_id)
+    update_reference(Identity, :user_id)
+    update_reference(Mailboxer::Receipt, :receiver_id)
+    update_reference(Mailboxer::Message, :sender_id)
+  end
+
+  def update_reference(model, column)
+    model.where(column => duplicate_ids).update_all(column => chosen_id)
+  end
+end

--- a/app/migrators/duplicate_username_migrator.rb
+++ b/app/migrators/duplicate_username_migrator.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'ruby-progressbar'
+require 'duplicate_username_user_chooser'
+require 'concerns/user_renamer'
+
+#
+# Takes care of removing duplicated usernames
+#
+class DuplicateUsernameMigrator
+  def initialize(username)
+    @username = username
+  end
+
+  def self.migrate!
+    duplicated_usernames = User.group('LOWER(username)')
+                               .having('COUNT(*) > 1')
+                               .pluck('LOWER(username)')
+
+    bar = ProgressBar.create(total: duplicated_usernames.size,
+                             format: '%a %B %c/%C')
+
+    duplicated_usernames.each do |username|
+      new(username).migrate!
+
+      bar.increment
+    end
+  end
+
+  def migrate!
+    duplicates.each { |user| UserRenamer.new(user).rename! }
+  end
+
+  private
+
+  def users
+    @users ||= User.where("LOWER(username) = '#{@username}'")
+  end
+
+  def duplicates
+    DuplicateUsernameUserChooser.new(users).duplicates
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,9 @@ class User < ActiveRecord::Base
 
   before_save :default_lang
 
-  validates :username, presence: true, uniqueness: true, length: { maximum: 63 }
+  validates :username, presence: true,
+                       uniqueness: { case_sensitive: false },
+                       length: { maximum: 63 }
 
   # Include default devise modules. Others available are:
   # :timeoutable and :omniauthable

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,10 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(:default, Rails.env)
 
+Class.new Rails::Railtie do
+  console { |_app| Bundler.require(:console) }
+end
+
 module NolotiroOrg
   class Application < Rails::Application
     config.time_zone = 'UTC'

--- a/db/migrate/20160728225113_add_username_unique_index_to_users.rb
+++ b/db/migrate/20160728225113_add_username_unique_index_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUsernameUniqueIndexToUsers < ActiveRecord::Migration
+  def change
+    add_index :users, :username, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160712194848) do
+ActiveRecord::Schema.define(version: 20160728225113) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace",     limit: 255
@@ -182,6 +182,7 @@ ActiveRecord::Schema.define(version: 20160712194848) do
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+  add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
   add_foreign_key "ads", "users", column: "user_owner"
   add_foreign_key "comments", "ads", column: "ads_id"

--- a/lib/tasks/nolotiro/users.rake
+++ b/lib/tasks/nolotiro/users.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :nolotiro do
+  desc '[nolotiro] Merge users with different case variations of same email'
+  task merge_duplicate_emails: :environment do
+    require 'duplicate_email_migrator'
+
+    DuplicateEmailMigrator.migrate!
+  end
+end

--- a/lib/tasks/nolotiro/users.rake
+++ b/lib/tasks/nolotiro/users.rake
@@ -7,4 +7,11 @@ namespace :nolotiro do
 
     DuplicateEmailMigrator.migrate!
   end
+
+  desc '[nolotiro] Standarize all emails in DB to lowercase'
+  task lowercase_emails: :environment do
+    ActiveRecord::Base.connection.execute <<-SQL.squish
+      UPDATE users SET email = LOWER(email)
+    SQL
+  end
 end

--- a/lib/tasks/nolotiro/users.rake
+++ b/lib/tasks/nolotiro/users.rake
@@ -14,4 +14,11 @@ namespace :nolotiro do
       UPDATE users SET email = LOWER(email)
     SQL
   end
+
+  desc '[nolotiro] Remove duplicated usernames from users table'
+  task fix_duplicate_usernames: :environment do
+    require 'duplicate_username_migrator'
+
+    DuplicateUsernameMigrator.migrate!
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -19,6 +19,17 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user2.errors[:username], 'ya está en uso'
   end
 
+  test 'has unique case insensitive usernames' do
+    user1 = FactoryGirl.build(:user, username: 'Username')
+    assert user1.valid?
+    assert user1.save
+
+    user2 = FactoryGirl.build(:user, username: 'username')
+    assert_not user2.valid?
+    assert_not user2.save
+    assert_includes user2.errors[:username], 'ya está en uso'
+  end
+
   test 'has unique emails' do
     user1 = FactoryGirl.build(:user, email: 'larryfoster@example.com')
     assert user1.valid?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -30,6 +30,13 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user2.errors[:email], 'ya está en uso'
   end
 
+  test 'saves downcased emails' do
+    user1 = FactoryGirl.build(:user, email: 'Larryfoster@example.com')
+    assert user1.valid?
+    assert user1.save
+    assert_equal 'larryfoster@example.com', user1.email
+  end
+
   test 'has passwords no shorter than 5 characters' do
     @user.password = '1234'
     assert_not @user.valid?


### PR DESCRIPTION
En #217 mergeamos un montón de usuarios con emails duplicados, pero no nos dimos cuenta de no permitir que entraran duplicados nuevos en el futuro (a día de hoy, 3 meses después, hay 18 nuevos duplicados).

Esta PR añade de nuevo la tarea para eliminar duplicados y además otra para pasar todos los emails a minúsculas (forma de prevenir que entren nuevos en el futuro). 

Además, también elimina duplicaciones en el username: Fixes #300.