### PR TITLE
Fix "want" tab when a status filter is active

### DIFF
--- a/app/views/woeid/show.html.erb
+++ b/app/views/woeid/show.html.erb
@@ -34,11 +34,11 @@
 <div id="location_header_section">
   <span class="give-want">
     <%= link_to t('nlt.give'),
-                url_for(params.merge(type: 'give')),
+                url_for(params.except(:page, :status).merge(type: 'give')),
                 class: @type == "give" ? "actual" : "''" %>
     &nbsp;
     <%= link_to t('nlt.want'),
-                url_for(params.merge(type: 'want')),
+                url_for(params.except(:page, :status).merge(type: 'want')),
                 class: @type == "want" ? "actual" : "''" %>
   </span>
 

--- a/test/integration/unauthenticated_ad_listing_test.rb
+++ b/test/integration/unauthenticated_ad_listing_test.rb
@@ -48,6 +48,17 @@ class UnauthenticatedAdListing < ActionDispatch::IntegrationTest
     end
   end
 
+  it 'lists wanted ads when a status filter is active' do
+    mocking_yahoo_woeid_info(766_273) do
+      visit ads_woeid_path(766_273, type: 'give')
+      click_link 'disponible'
+      click_link 'busco'
+    end
+
+    page.assert_text 'busco - Madrid, Madrid, España'
+    page.assert_selector '.ad_excerpt_list', count: 0
+  end
+
   private
 
   def mocking_location_counts


### PR DESCRIPTION
Arregla bug reportado por @iokese por el que nolotiro peta al hacer click en el tab de busco cuando hay algún filtro de status activo.