### PR TITLE
Get rid of mailboxer models

### DIFF
--- a/app/assets/stylesheets/_common.sass.erb
+++ b/app/assets/stylesheets/_common.sass.erb
@@ -941,7 +941,7 @@ $langs: <%= I18n.available_locales.join(" ") %>
   width: 300px
   height: 250px
 
-#mailboxer_message_body
+#message_body
   width: 90%
   height: 100px
 

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -1,15 +1,10 @@
 # frozen_string_literal: true
 class ConversationsController < ApplicationController
-  require 'will_paginate/array'
-
   before_action :authenticate_user!
 
   def index
     @conversations = conversations.includes(:receipts)
-                                  .sort_by { |c| c.last_message.created_at }
-                                  .reverse
-
-    @conversations = @conversations.paginate(page: params[:page], total_entries: @conversations.to_a.size)
+                                  .paginate(page: params[:page])
   end
 
   def new

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -9,11 +9,11 @@ class ConversationsController < ApplicationController
 
   def new
     @interlocutor = User.find(params[:user_id])
-    @message = Mailboxer::Message.new(recipients: @interlocutor.id)
+    @message = Message.new(recipients: @interlocutor.id)
   end
 
   def create
-    @interlocutor = User.find(params[:mailboxer_message][:recipients])
+    @interlocutor = User.find(params[:message][:recipients])
     @conversation = Conversation.new(subject: message_params[:subject])
 
     @message = @conversation.messages.build message_params.except(:subject)
@@ -53,7 +53,7 @@ class ConversationsController < ApplicationController
     @conversation = conversations.find(params[:id])
     @interlocutor = @conversation.interlocutor(current_user)
 
-    @message = Mailboxer::Message.new conversation: @conversation
+    @message = Message.new conversation: @conversation
     current_user.mark_as_read(@conversation)
   end
 
@@ -68,7 +68,7 @@ class ConversationsController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def message_params
-    params.require(:mailboxer_message)
+    params.require(:message)
           .permit(:body, :subject, :recipients)
           .merge(sender: current_user, recipients: [@interlocutor])
   end

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -39,7 +39,7 @@ class ConversationsController < ApplicationController
     @interlocutor = @conversation.interlocutor(current_user)
 
     @message = @conversation.messages.build message_params
-    @message.deliver
+    @message.deliver(true)
 
     if @message.valid?
       @conversation.receipts.untrash

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -37,7 +37,7 @@ class ConversationsController < ApplicationController
     @message.deliver(true)
 
     if @message.valid?
-      @conversation.receipts.untrash
+      @conversation.receipts.update_all(trashed: false)
 
       redirect_to mailboxer_conversation_path(@conversation),
                   notice: I18n.t('mailboxer.notifications.sent')

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 class Conversation < Mailboxer::Conversation
+  has_many :messages
+
+  scope :participant, ->(user) do
+    where(mailboxer_notifications: { type: 'Message' })
+      .order(updated_at: :desc)
+      .joins(:receipts)
+      .merge(Receipt.recipient(user))
+      .distinct
+  end
+
+  scope :not_trash, ->(user) { participant(user).merge(Receipt.not_trash) }
+
   def interlocutor(user)
     received_receipts = receipts.where.not(receiver_id: user.id)
     return unless received_receipts.any?

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,22 +1,52 @@
 # frozen_string_literal: true
 
-class Conversation < Mailboxer::Conversation
+class Conversation < ActiveRecord::Base
+  self.table_name = 'mailboxer_conversations'
+
+  validates :subject, presence: true, length: { maximum: 255 }
+
   has_many :messages
+  has_many :receipts, through: :messages
 
   scope :participant, ->(user) do
-    where(mailboxer_notifications: { type: 'Message' })
+    joins(:receipts)
       .order(updated_at: :desc)
-      .joins(:receipts)
       .merge(Receipt.recipient(user))
       .distinct
   end
 
   scope :not_trash, ->(user) { participant(user).merge(Receipt.not_trash) }
 
+  scope :unread, ->(user) { participant(user).merge(Receipt.unread) }
+
   def interlocutor(user)
     received_receipts = receipts.where.not(receiver_id: user.id)
     return unless received_receipts.any?
 
     received_receipts.first.receiver
+  end
+
+  def originator
+    original_message.sender
+  end
+
+  def original_message
+    @original_message ||= messages.order(:created_at).first
+  end
+
+  def unread?(user)
+    receipts_for(user).not_trash.unread.count != 0
+  end
+
+  def mark_as_read(user)
+    receipts_for(user).update_all(is_read: true)
+  end
+
+  def move_to_trash(participant)
+    receipts_for(participant).update_all(trashed: true)
+  end
+
+  def receipts_for(user)
+    Receipt.conversation(self).recipient(user)
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Message < Mailboxer::Message
+  belongs_to :conversation, validate: true, autosave: true
+
+  has_many :receipts, dependent: :destroy, foreign_key: :notification_id
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,7 +1,43 @@
 # frozen_string_literal: true
 
-class Message < Mailboxer::Message
+class Message < ActiveRecord::Base
+  self.table_name = 'mailboxer_notifications'
+
+  validates :sender, presence: true
+  validates :body, presence: true, length: { maximum: 32_000 }
+
   belongs_to :conversation, validate: true, autosave: true
+  belongs_to :sender, class_name: 'User'
 
   has_many :receipts, dependent: :destroy, foreign_key: :notification_id
+
+  attr_writer :recipients
+
+  def recipients
+    return Array.wrap(@recipients) unless @recipients.blank?
+
+    recipients  = receipts.includes(:receiver).map(&:receiver)
+
+    @recipients = Mailboxer::RecipientFilter.new(self, recipients).call
+  end
+
+  def deliver(reply = false)
+    receiver_receipts = recipients.map do |r|
+      receipts.build(receiver: r, mailbox_type: 'inbox', is_read: false)
+    end
+
+    sender_receipt =
+      receipts.build(receiver: sender, mailbox_type: 'sentbox', is_read: true)
+
+    if valid?
+      save!
+      Mailboxer::MailDispatcher.new(self, receiver_receipts).call
+
+      conversation.touch if reply
+
+      self.recipients = nil
+    end
+
+    sender_receipt
+  end
 end

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Receipt < Mailboxer::Receipt
+end

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -1,4 +1,18 @@
 # frozen_string_literal: true
 
-class Receipt < Mailboxer::Receipt
+class Receipt < ActiveRecord::Base
+  self.table_name = 'mailboxer_receipts'
+
+  belongs_to :receiver, class_name: 'User'
+  belongs_to :message, foreign_key: :notification_id
+
+  scope :recipient, ->(recipient) { where(receiver_id: recipient.id) }
+
+  scope :not_trash, -> { where(trashed: false) }
+  scope :unread, -> { where(is_read: false) }
+
+  scope :conversation, ->(conversation) do
+    joins(:message)
+      .where(mailboxer_notifications: { conversation_id: conversation.id })
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,9 +8,7 @@ class User < ActiveRecord::Base
   has_many :friendships
   has_many :friends, through: :friendships
 
-  has_many :receipts, class_name: 'Mailboxer::Receipt',
-                      dependent: :destroy,
-                      as: :receiver
+  has_many :receipts, as: :receiver, dependent: :destroy
 
   before_save :default_lang
 

--- a/app/views/conversations/_conversation.html.haml
+++ b/app/views/conversations/_conversation.html.haml
@@ -8,5 +8,5 @@
   %td.mail-subject
     = link_to c.subject, mailboxer_conversation_path(c)
   %td.timestamp
-    = cache "moment-#{timestamp}" do
-      %abbr.js-moment{title: timestamp}=timestamp
+    = cache "moment-#{c.updated_at}" do
+      %abbr.js-moment{title: c.updated_at}=c.updated_at

--- a/app/views/conversations/_conversation.html.haml
+++ b/app/views/conversations/_conversation.html.haml
@@ -1,4 +1,4 @@
-%tr{ class: "mail #{ 'unread' if c.is_unread?(current_user) }" }
+%tr{ class: "mail #{ 'unread' if c.unread?(current_user) }" }
   %td
     = check_box_tag '', c.id, false, id: "delete-conversation-#{c.id}",
                                      class: 'delete_multiple_checkbox',

--- a/app/views/conversations/_message.html.erb
+++ b/app/views/conversations/_message.html.erb
@@ -1,4 +1,4 @@
-<% if message.sender == message.conversation.original_message.sender %>
+<% if message.sender == message.conversation.originator %>
   <div class="message-excerpt">
     <div class="message-from-left">
       <% if message.sender %>

--- a/app/views/conversations/index.html.haml
+++ b/app/views/conversations/index.html.haml
@@ -13,8 +13,7 @@
           %table#mail-list.table.table-condensed
             %tbody
               - @conversations.each do |c|
-                = render partial: "conversations/conversation",
-                         locals: { c: c, timestamp: c.last_message.created_at }
+                = render partial: "conversations/conversation", locals: { c: c }
         = submit_tag t('mailboxer.buttons.trash_selected'), id: 'delete_multiple_button'
       = will_paginate @conversations
     - else

--- a/app/views/mailboxer/message_mailer/new_message_email.html.erb
+++ b/app/views/mailboxer/message_mailer/new_message_email.html.erb
@@ -12,7 +12,7 @@
 <b><%= I18n.t("mailboxer.message_mailer.message.body") %></b>
 <blockquote>
   <p>
-  <%= @message.body %>
+  <%= simple_format(@message.body) %>
   </p>
 </blockquote>
 

--- a/app/views/mailboxer/message_mailer/reply_message_email.html.erb
+++ b/app/views/mailboxer/message_mailer/reply_message_email.html.erb
@@ -12,7 +12,7 @@
 <b><%= I18n.t("mailboxer.message_mailer.message.body") %></b>
 <blockquote>
   <p>
-  <%= @message.body %>
+  <%= simple_format(@message.body) %>
   </p>
 </blockquote>
 

--- a/config/initializers/mailboxer.rb
+++ b/config/initializers/mailboxer.rb
@@ -10,6 +10,9 @@ Mailboxer.setup do |config|
   config.email_method = :mailboxer_email
   config.name_method = :name
 
+  # Mailer Class
+  config.message_mailer = Mailboxer::MessageMailer
+
   # Configures if you use or not a search engine and wich one are you using
   # Supported enignes: [:solr,:sphinx]
   config.search_enabled = false

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -19,7 +19,7 @@ ca:
       contact:
         email: 
         message: 
-      mailboxer/message:
+      message:
         body: Missatge
         subject: Assumpte
       user:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -19,7 +19,7 @@ de:
       contact:
         email: 
         message: 
-      mailboxer/message:
+      message:
         body: 
         subject: 
       user:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,7 +19,7 @@ en:
       contact:
         email: 
         message: 
-      mailboxer/message:
+      message:
         body: Message
         subject: Subject
       user:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -19,7 +19,7 @@ es:
       contact:
         email: Correo electrónico
         message: Mensaje
-      mailboxer/message:
+      message:
         body: Mensaje
         subject: Título
       user:

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -19,7 +19,7 @@ eu:
       contact:
         email: 
         message: 
-      mailboxer/message:
+      message:
         body: 
         subject: 
       user:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -19,7 +19,7 @@ fr:
       contact:
         email: 
         message: 
-      mailboxer/message:
+      message:
         body: 
         subject: 
       user:

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -19,7 +19,7 @@ gl:
       contact:
         email: Correo electrónico
         message: Mensaxe
-      mailboxer/message:
+      message:
         body: Mensaxe
         subject: Asunto
       user:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -19,7 +19,7 @@ it:
       contact:
         email: posta elettronica
         message: Messaggio
-      mailboxer/message:
+      message:
         body: Messaggio
         subject: Soggetto
       user:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -19,7 +19,7 @@ nl:
       contact:
         email: 
         message: 
-      mailboxer/message:
+      message:
         body: 
         subject: 
       user:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -19,7 +19,7 @@ pt:
       contact:
         email: Correio eletrônico
         message: Mensagem
-      mailboxer/message:
+      message:
         body: Mensagem
         subject: Título
       user:

--- a/test/controllers/conversations_controller.rb
+++ b/test/controllers/conversations_controller.rb
@@ -25,7 +25,7 @@ class ConversationsControllerTest < ActionController::TestCase
     # user1 signs in and sends a message to user2
     sign_in @user1
     assert_difference('Conversation.count') do
-      post :create, mailboxer_message: { recipients: @user2, body: 'lo sigues teniendo? ', subject: 'interesado en el ordenador' }
+      post :create, message: { recipients: @user2, body: 'lo sigues teniendo? ', subject: 'interesado en el ordenador' }
     end
     m = Conversation.last
     assert_redirected_to mailboxer_conversation_path(id: m.id)
@@ -53,7 +53,7 @@ class ConversationsControllerTest < ActionController::TestCase
   test 'should not get list of conversations to/from another user' do
     sign_in @user1
     assert_difference('Conversation.count') do
-      post :create, mailboxer_message: { recipients: @user2, body: 'lo sigues teniendo? ', subject: 'interesado en el ordenador' }
+      post :create, message: { recipients: @user2, body: 'lo sigues teniendo? ', subject: 'interesado en el ordenador' }
     end
     m = Conversation.last
     sign_out @user1
@@ -65,7 +65,7 @@ class ConversationsControllerTest < ActionController::TestCase
 
   test 'should not permit sender param for message' do
     sign_in @user1
-    post :create, mailboxer_message: { recipients: @user1, sender: @user2, body: 'lo sigues teniendo? ', subject: 'interesado en el ordenador' }
+    post :create, message: { recipients: @user1, sender: @user2, body: 'lo sigues teniendo? ', subject: 'interesado en el ordenador' }
     # TODO: finish
   end
 end

--- a/test/integration/concerns/messaging.rb
+++ b/test/integration/concerns/messaging.rb
@@ -10,8 +10,8 @@ module Messaging
   def send_message(params)
     subject = params[:subject]
 
-    fill_in('mailboxer_message_subject', with: subject) if subject
-    fill_in 'mailboxer_message_body', with: params[:body]
+    fill_in('message_subject', with: subject) if subject
+    fill_in 'message_body', with: params[:body]
     click_button 'Enviar'
   end
 end


### PR DESCRIPTION
He decido eliminar mailboxer también a nivel de modelos. Necesitamos flexibilidad para lo que viene (candidaturas, conversaciones al estilo whatsapp, bloqueos) y mailboxer continúa poniéndose en medio.

De momento he mantenido:

* El esquema de base de datos. Varias columnas ya no se usan pero de momento no toco nada por simplicidad.
* El envío de emails, que lo sigue haciendo mailboxer.