### PR TITLE
Removed messages don't come back

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -37,8 +37,6 @@ class ConversationsController < ApplicationController
     @message.deliver(true)
 
     if @message.valid?
-      @conversation.receipts.update_all(trashed: false)
-
       redirect_to mailboxer_conversation_path(@conversation),
                   notice: I18n.t('mailboxer.notifications.sent')
     else

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -34,6 +34,10 @@ class Conversation < ActiveRecord::Base
     @original_message ||= messages.order(:created_at).first
   end
 
+  def messages_for(user)
+    messages.not_trashed_by(user)
+  end
+
   def unread?(user)
     receipts_for(user).not_trash.unread.count != 0
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -11,6 +11,10 @@ class Message < ActiveRecord::Base
 
   has_many :receipts, dependent: :destroy, foreign_key: :notification_id
 
+  scope :not_trashed_by, ->(user) do
+    joins(:receipts).merge(Receipt.recipient(user).not_trash)
+  end
+
   attr_writer :recipients
 
   def recipients

--- a/app/views/conversations/show.html.haml
+++ b/app/views/conversations/show.html.haml
@@ -10,7 +10,7 @@
   = link_to t("mailboxer.buttons.trash"), trash_mailboxer_conversation_path(@conversation), class: :button, method: :delete
 
 .col-md-7.col-sm-7#messages-thread
-  - @conversation.messages.includes(:sender).each do |mes|
+  - @conversation.messages_for(current_user).includes(:sender).each do |mes|
     = render partial: "message", locals: {message: mes}
 
   - if @interlocutor

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -199,8 +199,8 @@ ca:
   mailboxer:
     buttons:
       back: "<Tornar a missatges"
-      trash: Arxivar conversa
-      trash_selected: Arxivar converses seleccionats
+      trash: Esborrar conversa
+      trash_selected: Esborrar converses seleccionats
     message_mailer:
       message:
         body: missatge
@@ -228,7 +228,7 @@ ca:
       you_have_recieved_new_reply: Has rebut una nova resposta
     notifications:
       sent: missatge enviat
-      trash: Conversa arxivada
+      trash: Conversa esborrat
     search: Resultats de cerca de %{search}
     table:
       date: Fecha

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,8 +195,8 @@ en:
   mailboxer:
     buttons:
       back: "< back to messages"
-      trash: Archive conversation
-      trash_selected: Archive selected conversations
+      trash: Delete conversation
+      trash_selected: Delete selected conversations
     message_mailer:
       message:
         body: Message
@@ -224,7 +224,7 @@ en:
       you_have_recieved_new_reply: You have a new answer
     notifications:
       sent: Sent message
-      trash: Conversation archived
+      trash: Conversation deleted
     search: Search results %{search}
     table:
       date: Date

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -199,8 +199,8 @@ es:
   mailboxer:
     buttons:
       back: "< volver a mensajes"
-      trash: Archivar conversación
-      trash_selected: Archivar conversaciones seleccionadas
+      trash: Borrar conversación
+      trash_selected: Borrar conversaciones seleccionadas
     message_mailer:
       message:
         body: Mensaje
@@ -228,7 +228,7 @@ es:
       you_have_recieved_new_reply: Has recibido una nueva respuesta
     notifications:
       sent: Mensaje enviado
-      trash: Conversación archivada
+      trash: Conversación borrada
     search: Resultados de busqueda de %{search}
     table:
       date: Fecha

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -206,8 +206,8 @@ gl:
   mailboxer:
     buttons:
       back: 
-      trash: Arquivar conversa
-      trash_selected: Arquivar conversas seleccionadas
+      trash: Eliminar conversa
+      trash_selected: Eliminar conversas seleccionadas
     message_mailer:
       message:
         body: Mensaxe

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -199,8 +199,8 @@ it:
   mailboxer:
     buttons:
       back: "< torna al messaggio"
-      trash: Archiviare la conversazione
-      trash_selected: Archiviare le conversazioni selezionati
+      trash: Cancellare la conversazione
+      trash_selected: Cancellare le conversazioni selezionati
     message_mailer:
       message:
         body: Messaggio
@@ -228,7 +228,7 @@ it:
       you_have_recieved_new_reply: Hai ricevuto una nuova risposta
     notifications:
       sent: Messaggio inviato
-      trash: Conversazione archiviata
+      trash: Conversazione cancellata
     search: Risultati della ricerca su %{search}
     table:
       date: Data

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -199,8 +199,8 @@ pt:
   mailboxer:
     buttons:
       back: "< voltar a mensagens"
-      trash: Arquivar conversa
-      trash_selected: Arquivar conversas selecionadas
+      trash: Apagar conversa
+      trash_selected: Apagar conversas selecionadas
     message_mailer:
       message:
         body: Mensagem
@@ -228,7 +228,7 @@ pt:
       you_have_recieved_new_reply: Você têm uma nova resposta
     notifications:
       sent: Mensagem enviada
-      trash: Conversa arquivada
+      trash: Conversa apagada
     search: Resultados da busca de %{search}
     table:
       date: Data

--- a/test/integration/concerns/standard_messages.rb
+++ b/test/integration/concerns/standard_messages.rb
@@ -120,7 +120,7 @@ module StandardMessages
     send_message(body: 'hombre, tú por aquí')
 
     login_as @user1
-    visit messages_list_path
-    assert_content 'hola mundo'
+    visit mailboxer_conversation_path(Conversation.first)
+    assert_content 'What a nice message!'
   end
 end

--- a/test/integration/concerns/standard_messages.rb
+++ b/test/integration/concerns/standard_messages.rb
@@ -91,10 +91,10 @@ module StandardMessages
 
   def test_deletes_a_single_conversation_and_shows_a_confirmation_flash
     send_message(subject: 'hola mundo', body: 'What a nice message!')
-    click_link 'Archivar conversación'
+    click_link 'Borrar conversación'
 
     refute_content 'hola mundo'
-    assert_content 'Conversación archivada'
+    assert_content 'Conversación borrada'
   end
 
   def test_deletes_multiple_conversations_by_checkbox
@@ -104,7 +104,7 @@ module StandardMessages
 
     visit messages_list_path
     check("delete-conversation-#{Conversation.first.id}")
-    click_button 'Archivar conversaciones seleccionadas'
+    click_button 'Borrar conversaciones seleccionadas'
 
     refute_content 'hola mundo'
     assert_content 'hola marte'
@@ -112,7 +112,7 @@ module StandardMessages
 
   def test_does_not_revive_deleted_conversation_when_the_other_user_replies
     send_message(subject: 'hola mundo', body: 'What a nice message!')
-    click_link 'Archivar conversación'
+    click_link 'Borrar conversación'
     refute_content 'hola mundo'
 
     login_as @user2

--- a/test/integration/concerns/standard_messages.rb
+++ b/test/integration/concerns/standard_messages.rb
@@ -110,7 +110,7 @@ module StandardMessages
     assert_content 'hola marte'
   end
 
-  def revives_deleted_conversation_when_the_other_user_replies_again
+  def test_revives_deleted_conversation_when_the_other_user_replies_again
     send_message(subject: 'hola mundo', body: 'What a nice message!')
     click_link 'Archivar conversación'
     refute_content 'hola mundo'

--- a/test/integration/concerns/standard_messages.rb
+++ b/test/integration/concerns/standard_messages.rb
@@ -110,7 +110,7 @@ module StandardMessages
     assert_content 'hola marte'
   end
 
-  def test_revives_deleted_conversation_when_the_other_user_replies_again
+  def test_revives_deleted_conversation_when_the_other_user_replies
     send_message(subject: 'hola mundo', body: 'What a nice message!')
     click_link 'Archivar conversación'
     refute_content 'hola mundo'

--- a/test/integration/concerns/standard_messages.rb
+++ b/test/integration/concerns/standard_messages.rb
@@ -110,7 +110,7 @@ module StandardMessages
     assert_content 'hola marte'
   end
 
-  def test_revives_deleted_conversation_when_the_other_user_replies
+  def test_does_not_revive_deleted_conversation_when_the_other_user_replies
     send_message(subject: 'hola mundo', body: 'What a nice message!')
     click_link 'Archivar conversación'
     refute_content 'hola mundo'
@@ -121,6 +121,6 @@ module StandardMessages
 
     login_as @user1
     visit mailboxer_conversation_path(Conversation.first)
-    assert_content 'What a nice message!'
+    refute_content 'What a nice message!'
   end
 end


### PR DESCRIPTION
Previamente si el usuario borraba una conversación pero el interlocutor contestaba posteriormente, toda la conversación volvía a aparecer.

Esto puede sorprender a algunos usuarios, así que lo he cambiado y los mensajes borrados nunca vuelven a aparecer. Esto nos alinea con lo que hacen Telegram y Whatsapp. 