### PR TITLE
Touching conversations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,9 +68,7 @@ gem 'geoplanet',
 gem 'maxminddb'                                     # geolite city v2
 gem 'will_paginate', '~> 3.0'                       # pagination
 gem 'devise'                                        # users
-gem 'devise-i18n',
-    github: 'deivid-rodriguez/devise-i18n',
-    branch: 'patch-1'                               # devise translations
+gem 'devise-i18n', github: 'tigrish/devise-i18n'    # devise translations
 gem 'omniauth'                                      # users login with providers
 gem 'omniauth-facebook'                             # users login with facebook
 gem 'omniauth-google-oauth2'                        # users login with google

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,13 +18,6 @@ GIT
       sprockets (< 4)
 
 GIT
-  remote: git://github.com/deivid-rodriguez/devise-i18n.git
-  revision: ce02b6f202b82d16eeef458a1aceb40498478977
-  branch: patch-1
-  specs:
-    devise-i18n (1.1.0)
-
-GIT
   remote: git://github.com/deivid-rodriguez/geoplanet.git
   revision: 1602a6163782dd1df28c0195460275f4806e4229
   branch: better_exceptions
@@ -32,6 +25,12 @@ GIT
     geoplanet (0.2.7)
       json (>= 1.1.3)
       rest-client (>= 0.9)
+
+GIT
+  remote: git://github.com/tigrish/devise-i18n.git
+  revision: a849867a65994ac80a94a909782a76fa94bb25b9
+  specs:
+    devise-i18n (1.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/app/controllers/ads_controller.rb
+++ b/app/controllers/ads_controller.rb
@@ -29,9 +29,12 @@ class AdsController < ApplicationController
 
   # GET /ads/new
   def new
-    @ad = Ad.new
-    @ad.comments_enabled = true
-    redirect_to location_ask_path if current_user.woeid.nil?
+    if current_user.woeid.nil?
+      redirect_to location_ask_path
+    else
+      @ad = Ad.new
+      @ad.comments_enabled = true
+    end
   end
 
   # GET /ads/1/edit

--- a/app/controllers/ads_controller.rb
+++ b/app/controllers/ads_controller.rb
@@ -23,7 +23,6 @@ class AdsController < ApplicationController
   # GET /ads/1
   # GET /ads/1.json
   def show
-    redirect_to ads_path unless @ad.user
     @comment = Comment.new
     @ad.increment_readed_count!
   end

--- a/app/controllers/ads_controller.rb
+++ b/app/controllers/ads_controller.rb
@@ -17,9 +17,7 @@ class AdsController < ApplicationController
   end
 
   def list
-    @ads = Rails.cache.fetch("ads_list_#{params[:page]}") do
-      Ad.give.available.includes(:user).paginate(page: params[:page])
-    end
+    @ads = Ad.give.available.includes(:user).paginate(page: params[:page])
   end
 
   # GET /ads/1

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -15,13 +15,6 @@ class Ability
     unless user.username.nil?
       can :create, Ad
       can :create, Comment
-      can :create, Mailboxer::Message
-      # FIXME: not working on messages_controller.rb
-      # can :create, :show, Conversation do |conversation|
-      #  conversation.is_participant? user
-      # end
-      can :list, Mailboxer::Message, user_from: user.id
-      can :list, Mailboxer::Message, user_to: user.id
       cannot :lock, Admin
       cannot :unlock, Admin
       cannot :become, Admin

--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -25,14 +25,11 @@ class Ad < ActiveRecord::Base
   belongs_to :user, foreign_key: 'user_owner', counter_cache: true
   has_many :comments, foreign_key: 'ads_id', dependent: :destroy
 
-  validates :title, presence: true
-  validates :body, presence: true
+  validates :title, presence: true, length: { minimum: 4, maximum: 100 }
+  validates :body, presence: true, length: { minimum: 25, maximum: 1000 }
   validates :user_owner, presence: true
   validates :woeid_code, presence: true
   validates :ip, presence: true
-
-  validates :title, length: { minimum: 4, maximum: 100 }
-  validates :body, length: { minimum: 25, maximum: 1000 }
 
   validates :status,
             inclusion: { in: [1, 2, 3], message: 'no es un estado válido' },

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -52,8 +52,8 @@ class Conversation < ActiveRecord::Base
     receipts_for(user).update_all(is_read: true)
   end
 
-  def move_to_trash(participant)
-    receipts_for(participant).update_all(trashed: true)
+  def move_to_trash(user)
+    receipts_for(user).update_all(trashed: true)
   end
 
   def receipts_for(user)

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -57,6 +57,6 @@ class Conversation < ActiveRecord::Base
   end
 
   def receipts_for(user)
-    Receipt.conversation(self).recipient(user)
+    receipts.recipient(user)
   end
 end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -6,16 +6,16 @@ class Conversation < ActiveRecord::Base
   has_many :messages
   has_many :receipts, through: :messages
 
-  scope :participant, ->(user) do
+  scope :involving, ->(user) do
     joins(:receipts)
       .order(updated_at: :desc)
       .merge(Receipt.recipient(user))
       .distinct
   end
 
-  scope :not_trash, ->(user) { participant(user).merge(Receipt.not_trash) }
+  scope :untrashed, ->(user) { involving(user).merge(Receipt.untrashed) }
 
-  scope :unread, ->(user) { participant(user).merge(Receipt.unread) }
+  scope :unread, ->(user) { involving(user).merge(Receipt.unread) }
 
   def envelope_for(sender:, recipient:, body: '')
     message = messages.build(sender: sender, body: body)
@@ -41,11 +41,11 @@ class Conversation < ActiveRecord::Base
   end
 
   def messages_for(user)
-    messages.not_trashed_by(user)
+    messages.untrashed(user)
   end
 
   def unread?(user)
-    receipts_for(user).not_trash.unread.count != 0
+    receipts_for(user).untrashed.unread.count != 0
   end
 
   def mark_as_read(user)

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -45,18 +45,8 @@ class Conversation < ActiveRecord::Base
   end
 
   def unread?(user)
-    receipts_for(user).untrashed.unread.count != 0
+    messages.unread(user).count != 0
   end
 
-  def mark_as_read(user)
-    receipts_for(user).update_all(is_read: true)
-  end
-
-  def move_to_trash(user)
-    receipts_for(user).update_all(trashed: true)
-  end
-
-  def receipts_for(user)
-    receipts.recipient(user)
-  end
+  delegate :mark_as_read, :move_to_trash, to: :receipts
 end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -18,6 +18,8 @@ class Conversation < ActiveRecord::Base
   scope :unread, ->(user) { involving(user).merge(Receipt.unread) }
 
   def envelope_for(sender:, recipient:, body: '')
+    self.updated_at = Time.zone.now
+
     message = messages.build(sender: sender, body: body)
 
     message.envelope_for(recipient)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -13,6 +13,8 @@ class Message < ActiveRecord::Base
     joins(:receipts).merge(Receipt.recipient(user).untrashed)
   end
 
+  scope :unread, ->(user) { untrashed(user).merge(Receipt.unread) }
+
   def recipient_receipt
     receipts.find_by(mailbox_type: 'inbox')
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -9,8 +9,8 @@ class Message < ActiveRecord::Base
 
   has_many :receipts, dependent: :destroy, foreign_key: :notification_id
 
-  scope :not_trashed_by, ->(user) do
-    joins(:receipts).merge(Receipt.recipient(user).not_trash)
+  scope :untrashed, ->(user) do
+    joins(:receipts).merge(Receipt.recipient(user).untrashed)
   end
 
   def recipient_receipt

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -6,7 +6,7 @@ class Receipt < ActiveRecord::Base
 
   scope :recipient, ->(recipient) { where(receiver_id: recipient.id) }
 
-  scope :not_trash, -> { where(trashed: false) }
+  scope :untrashed, -> { where(trashed: false) }
   scope :unread, -> { where(is_read: false) }
 
   scope :conversation, ->(conversation) do

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -7,5 +7,13 @@ class Receipt < ActiveRecord::Base
   scope :recipient, ->(recipient) { where(receiver_id: recipient.id) }
 
   scope :untrashed, -> { where(trashed: false) }
-  scope :unread, -> { where(is_read: false) }
+  scope :unread, -> { untrashed.where(is_read: false) }
+
+  def self.mark_as_read(user)
+    recipient(user).update_all(is_read: true)
+  end
+
+  def self.move_to_trash(user)
+    recipient(user).update_all(trashed: true)
+  end
 end

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -8,8 +8,4 @@ class Receipt < ActiveRecord::Base
 
   scope :untrashed, -> { where(trashed: false) }
   scope :unread, -> { where(is_read: false) }
-
-  scope :conversation, ->(conversation) do
-    joins(:message).where(messages: { conversation_id: conversation.id })
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,7 +69,7 @@ class User < ActiveRecord::Base
   end
 
   def conversations
-    @conversations ||= Conversation.not_trash(self)
+    @conversations ||= Conversation.untrashed(self)
   end
 
   def unread_messages_count

--- a/app/views/users/_tabnav.html.erb
+++ b/app/views/users/_tabnav.html.erb
@@ -1,6 +1,6 @@
 <ul id="tabnav">
   <!-- TODO: can an user edit or view messages from another user? -->
-  <% if user_signed_in? and user.id == current_user.id %>
+  <% if user_signed_in? and user == current_user %>
     <li>
       <%= link_to t('nlt.messages'),
                   conversations_path,

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -12,7 +12,7 @@
       <h4><%= t('nlt.member_since') %>: <%= l @user.created_at, format: :long %></h4>
       <ul>
 
-        <% if user_signed_in? and @user.id == current_user.id %>  
+        <% if user_signed_in? and @user == current_user %>  
           <li>                                                                         
             <%= link_to t('nlt.user_edit_profile'), user_edit_path(@user) %>                      
           </li>
@@ -63,7 +63,7 @@
         </li>
       <% end %>
 
-      <% unless user_signed_in? and @user.id == current_user.id %>  
+      <% unless user_signed_in? and @user == current_user %>  
 
         <% if can? :become, @user %>
           <li>

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -5,10 +5,10 @@ class AdminControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
   setup do
-    @ad = FactoryGirl.create(:ad)
-    @user = FactoryGirl.create(:user)
-    @another_user = FactoryGirl.create(:user)
-    @admin = FactoryGirl.create(:admin)
+    @ad = create(:ad)
+    @user = create(:user)
+    @another_user = create(:user)
+    @admin = create(:admin)
   end
 
   test 'should not become an user as a anonymous user' do

--- a/test/controllers/ads_controller_test.rb
+++ b/test/controllers/ads_controller_test.rb
@@ -7,9 +7,9 @@ class AdsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
   setup do
-    @ad = FactoryGirl.create(:ad)
-    @user = FactoryGirl.create(:user)
-    @admin = FactoryGirl.create(:admin)
+    @ad = create(:ad)
+    @user = create(:user)
+    @admin = create(:admin)
   end
 
   test 'should get index' do

--- a/test/controllers/api/v1_controller_test.rb
+++ b/test/controllers/api/v1_controller_test.rb
@@ -7,7 +7,7 @@ module Api
   class V1ControllerTest < ActionController::TestCase
     include WebMocking
 
-    setup { @ad = FactoryGirl.create(:ad, woeid_code: 766_273) }
+    setup { @ad = create(:ad, woeid_code: 766_273) }
 
     test 'should get woeid list on api v1' do
       mocking_yahoo_woeid_info(766_273) do

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -5,8 +5,8 @@ class CommentsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
   setup do
-    @ad = FactoryGirl.create(:ad)
-    @user = FactoryGirl.create(:user, 'email' => 'jaimito@gmail.com', 'username' => 'jaimito')
+    @ad = create(:ad)
+    @user = create(:user, 'email' => 'jaimito@gmail.com', 'username' => 'jaimito')
   end
 
   test 'should not create a comment as anonymous' do

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -6,7 +6,6 @@ class CommentsControllerTest < ActionController::TestCase
 
   setup do
     @ad = create(:ad)
-    @user = create(:user, 'email' => 'jaimito@gmail.com', 'username' => 'jaimito')
   end
 
   test 'should not create a comment as anonymous' do
@@ -18,7 +17,7 @@ class CommentsControllerTest < ActionController::TestCase
   end
 
   test 'should create a comment as a user' do
-    sign_in @user
+    sign_in @ad.user
     assert_difference('Comment.count', 1) do
       post :create, id: @ad.id, body: 'hola mundo'
     end

--- a/test/controllers/conversations_controller.rb
+++ b/test/controllers/conversations_controller.rb
@@ -5,9 +5,9 @@ class ConversationsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
   setup do
-    @ad = FactoryGirl.create(:ad)
-    @user1 = FactoryGirl.create(:user, 'email' => 'davidbowie@gmail.com', 'username' => 'davidbowie')
-    @user2 = FactoryGirl.create(:user, 'email' => 'marcbolan@gmail.com', 'username' => 'trex')
+    @ad = create(:ad)
+    @user1 = create(:user, 'email' => 'davidbowie@gmail.com', 'username' => 'davidbowie')
+    @user2 = create(:user, 'email' => 'marcbolan@gmail.com', 'username' => 'trex')
   end
 
   test 'should redirect to signup to create a message as anon' do
@@ -57,7 +57,7 @@ class ConversationsControllerTest < ActionController::TestCase
     end
     m = Conversation.last
     sign_out @user1
-    user3 = FactoryGirl.create(:user, 'email' => 'brianeno@gmail.com', 'username' => 'eno')
+    user3 = create(:user, 'email' => 'brianeno@gmail.com', 'username' => 'eno')
     sign_in user3
     get :show, id: m.id
     assert_equal 'No tienes permisos para realizar esta acción.', flash[:alert]

--- a/test/controllers/friendships_controller_test.rb
+++ b/test/controllers/friendships_controller_test.rb
@@ -5,8 +5,8 @@ class FriendshipsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
   setup do
-    @user = FactoryGirl.create(:user)
-    @friend = FactoryGirl.create(:user, 'email' => 'jaimito@gmail.com', 'username' => 'jaimito')
+    @user = create(:user)
+    @friend = create(:user, 'email' => 'jaimito@gmail.com', 'username' => 'jaimito')
   end
 
   test 'should not create a friend as anonymous user' do

--- a/test/controllers/location_controller_test.rb
+++ b/test/controllers/location_controller_test.rb
@@ -7,7 +7,7 @@ class LocationControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
   setup do
-    @user = FactoryGirl.create(:user)
+    @user = create(:user)
     @request.headers['REMOTE_ADDR'] = '87.223.138.147'
   end
 

--- a/test/controllers/rss_controller_test.rb
+++ b/test/controllers/rss_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 class RssControllerTest < ActionController::TestCase
   setup do
-    @ad = FactoryGirl.create(:ad)
+    @ad = create(:ad)
   end
 
   test 'should get the feed for a WOEID' do

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -6,7 +6,7 @@ class SearchControllerTest < ActionController::TestCase
   include WebMocking
   include Devise::Test::ControllerHelpers
 
-  setup { @ad = FactoryGirl.create(:ad) }
+  setup { @ad = create(:ad) }
 
   test 'search works with a WOEID code param' do
     mocking_yahoo_woeid_info(@ad.woeid_code) do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -5,8 +5,8 @@ class UsersControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
   setup do
-    @ad = FactoryGirl.create(:ad)
-    @user = FactoryGirl.create(:user, 'email' => 'jaimito@gmail.com', 'username' => 'jaimito')
+    @ad = create(:ad)
+    @user = create(:user, 'email' => 'jaimito@gmail.com', 'username' => 'jaimito')
   end
 
   test 'should get user profile by username' do

--- a/test/controllers/woeid_controller_test.rb
+++ b/test/controllers/woeid_controller_test.rb
@@ -7,7 +7,7 @@ class WoeidControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
   setup do
-    @ad = FactoryGirl.create(:ad)
+    @ad = create(:ad)
   end
 
   test 'should get listall and give (available, delivered, booked)' do

--- a/test/factories/conversation.rb
+++ b/test/factories/conversation.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :conversation do
+    transient do
+      originator { create(:user) }
+      recipient { create(:user) }
+    end
+
+    subject 'Talking about presents'
+
+    after(:build) do |conversation, evaluator|
+      conversation.envelope_for(sender: evaluator.originator,
+                                recipient: evaluator.recipient,
+                                body: 'The start of a beautiful friendship')
+    end
+  end
+end

--- a/test/helpers/ad_helper_test.rb
+++ b/test/helpers/ad_helper_test.rb
@@ -5,7 +5,7 @@ require 'support/web_mocking'
 class AdHelperTest < ActionView::TestCase
   include WebMocking
 
-  setup { @ad = FactoryGirl.create(:ad, woeid_code: 766_273) }
+  setup { @ad = create(:ad, woeid_code: 766_273) }
 
   test 'should get locations ranking' do
     mocking_yahoo_woeid_info(766_273) do

--- a/test/integration/ad_management_test.rb
+++ b/test/integration/ad_management_test.rb
@@ -8,7 +8,7 @@ class AdManagementTest < ActionDispatch::IntegrationTest
   include Authentication
 
   before do
-    @user = FactoryGirl.create(:user)
+    @user = create(:user)
     login_as @user
   end
 

--- a/test/integration/can_access_admin_test.rb
+++ b/test/integration/can_access_admin_test.rb
@@ -45,10 +45,10 @@ class CanAccessAdmin < ActionDispatch::IntegrationTest
   private
 
   def user
-    @user ||= FactoryGirl.create(:user)
+    @user ||= create(:user)
   end
 
   def admin
-    @admin ||= FactoryGirl.create(:admin)
+    @admin ||= create(:admin)
   end
 end

--- a/test/integration/concerns/self_messages.rb
+++ b/test/integration/concerns/self_messages.rb
@@ -8,8 +8,8 @@ module SelfMessages
   def setup
     super
 
-    @user1 = FactoryGirl.create(:user, username: 'user1')
-    @user2 = FactoryGirl.create(:user, username: 'user2')
+    @user1 = create(:user, username: 'user1')
+    @user2 = create(:user, username: 'user2')
 
     login_as @user1
 

--- a/test/integration/concerns/standard_messages.rb
+++ b/test/integration/concerns/standard_messages.rb
@@ -8,8 +8,8 @@ module StandardMessages
   def setup
     super
 
-    @user1 = FactoryGirl.create(:user, username: 'user1')
-    @user2 = FactoryGirl.create(:user, username: 'user2')
+    @user1 = create(:user, username: 'user1')
+    @user2 = create(:user, username: 'user2')
 
     login_as @user1
 

--- a/test/integration/edition_by_admin_test.rb
+++ b/test/integration/edition_by_admin_test.rb
@@ -8,8 +8,8 @@ class EditionsByAdmin < ActionDispatch::IntegrationTest
   include Authentication
 
   before do
-    @ad = FactoryGirl.create(:ad, woeid_code: 766_273, type: 1)
-    login_as FactoryGirl.create(:admin, woeid: 766_272)
+    @ad = create(:ad, woeid_code: 766_273, type: 1)
+    login_as create(:admin, woeid: 766_272)
   end
 
   it 'changes only the edited attribute' do

--- a/test/integration/friendships_test.rb
+++ b/test/integration/friendships_test.rb
@@ -7,8 +7,8 @@ class FriendshipsTest < ActionDispatch::IntegrationTest
   include Authentication
 
   before do
-    @user = FactoryGirl.create(:user)
-    @friend = FactoryGirl.create(:user)
+    @user = create(:user)
+    @friend = create(:user)
 
     login_as @user
     visit profile_path(@friend)

--- a/test/integration/legacy_routing_test.rb
+++ b/test/integration/legacy_routing_test.rb
@@ -6,10 +6,10 @@ class LegacyRoutingTest < ActionDispatch::IntegrationTest
   include WebMocking
 
   setup do
-    @ad = FactoryGirl.create(:ad)
-    @user = FactoryGirl.create(:user)
-    @another_user = FactoryGirl.create(:user)
-    @admin = FactoryGirl.create(:admin)
+    @ad = create(:ad)
+    @user = create(:user)
+    @another_user = create(:user)
+    @admin = create(:admin)
   end
 
   I18n.available_locales.map(&:to_s).each do |l|

--- a/test/integration/links_for_available_ads_test.rb
+++ b/test/integration/links_for_available_ads_test.rb
@@ -6,7 +6,7 @@ class LinksForAvailableAdsTest < ActionDispatch::IntegrationTest
   include WebMocking
 
   before do
-    @ad = FactoryGirl.create(:ad, status: 1, comments_enabled: true)
+    @ad = create(:ad, status: 1, comments_enabled: true)
     @woeid_code = @ad.woeid_code
   end
 

--- a/test/integration/links_for_booked_ads_test.rb
+++ b/test/integration/links_for_booked_ads_test.rb
@@ -6,7 +6,7 @@ class LinksForBookedAdsTest < ActionDispatch::IntegrationTest
   include WebMocking
 
   before do
-    @ad = FactoryGirl.create(:ad, status: 2, comments_enabled: true)
+    @ad = create(:ad, status: 2, comments_enabled: true)
     @woeid_code = @ad.woeid_code
   end
 

--- a/test/integration/links_for_delivered_ads_test.rb
+++ b/test/integration/links_for_delivered_ads_test.rb
@@ -6,7 +6,7 @@ class LinksForDeliveredAds < ActionDispatch::IntegrationTest
   include WebMocking
 
   before do
-    @ad = FactoryGirl.create(:ad, status: 3, comments_enabled: true)
+    @ad = create(:ad, status: 3, comments_enabled: true)
     @woeid_code = @ad.woeid_code
   end
 

--- a/test/integration/user_lockable_test.rb
+++ b/test/integration/user_lockable_test.rb
@@ -6,7 +6,7 @@ class UserLockable < ActionDispatch::IntegrationTest
   include Authentication
 
   it 'should lock after 10 tries on user' do
-    @user = FactoryGirl.create(:user)
+    @user = create(:user)
 
     8.times do
       login(@user.email, 'trololololo')

--- a/test/models/ad_test.rb
+++ b/test/models/ad_test.rb
@@ -8,7 +8,7 @@ class AdTest < ActiveSupport::TestCase
   include WebMocking
 
   setup do
-    @ad = FactoryGirl.create(:ad)
+    @ad = create(:ad)
   end
 
   test 'ad requires everything' do
@@ -170,7 +170,7 @@ class AdTest < ActiveSupport::TestCase
   end
 
   test 'associated comments are deleted when ad is deleted' do
-    FactoryGirl.create(:comment, ad: @ad)
+    create(:comment, ad: @ad)
 
     assert_difference(-> { Comment.count }, -1) { @ad.destroy }
   end

--- a/test/models/ad_test.rb
+++ b/test/models/ad_test.rb
@@ -7,9 +7,7 @@ require 'support/web_mocking'
 class AdTest < ActiveSupport::TestCase
   include WebMocking
 
-  setup do
-    @ad = create(:ad)
-  end
+  setup { @ad = create(:ad) }
 
   test 'ad requires everything' do
     a = Ad.new
@@ -88,48 +86,40 @@ class AdTest < ActiveSupport::TestCase
 
   test 'ad check type_string' do
     assert_equal @ad.type_string, 'regalo'
-    @ad.type = 2
-    @ad.save
+    @ad.update(type: 2)
     assert_equal @ad.type_string, 'busco'
   end
 
   test 'ad check status_string' do
     assert_equal @ad.status_string, 'disponible'
-    @ad.status = 2
-    @ad.save
+    @ad.update(status: 2)
     assert_equal @ad.status_string, 'reservado'
-    @ad.status = 3
-    @ad.save
+    @ad.update(status: 3)
     assert_equal @ad.status_string, 'entregado'
   end
 
   test 'ad check type_class' do
     assert_equal @ad.type_class, 'give'
-    @ad.type = 2
-    @ad.save
+    @ad.update(type: 2)
     assert_equal @ad.type_class, 'want'
   end
 
   test 'ad check status_class' do
     assert_equal @ad.status_class, 'available'
-    @ad.status = 2
-    @ad.save
+    @ad.update(status: 2)
     assert_equal @ad.status_class, 'booked'
-    @ad.status = 3
-    @ad.save
+    @ad.update(status: 3)
     assert_equal @ad.status_class, 'delivered'
   end
 
   test 'ad give?' do
-    @ad.type = 1
-    @ad.save
+    @ad.update(type: 1)
     assert_equal @ad.give?, true
   end
 
   test 'ad meta_title for give ads' do
     mocking_yahoo_woeid_info(@ad.woeid_code) do
-      @ad.type = 1
-      @ad.save
+      @ad.update(type: 1)
       title = 'regalo segunda mano gratis  ordenador en Vallecas Madrid, ' \
               'Madrid, España'
       assert_equal title, @ad.meta_title
@@ -140,8 +130,7 @@ class AdTest < ActiveSupport::TestCase
     skip
 
     mocking_yahoo_woeid_info(@ad.woeid_code) do
-      @ad.type = 2
-      @ad.save
+      @ad.update(type: 2)
       title = 'busco ordenador en Vallecas Madrid, Madrid, España'
       assert_equal title, @ad.meta_title
     end
@@ -150,8 +139,7 @@ class AdTest < ActiveSupport::TestCase
   test 'ad body shoudl store emoji' do
     skip
     body = 'What a nice emoji😀!What a nice emoji😀!What a nice emoji😀!What a nice emoji😀!What a nice emoji😀!'
-    @ad.body = body
-    @ad.save
+    @ad.update(body: body)
     assert_equal @ad.body, body
   end
 

--- a/test/models/conversation_test.rb
+++ b/test/models/conversation_test.rb
@@ -35,4 +35,11 @@ class ConversationTest < ActiveSupport::TestCase
     assert_equal false, @conversation.unread?(@user)
     assert_equal true, @conversation.unread?(@recipient)
   end
+
+  def test_envelope_for_touches_the_conversation_timestamp
+    @conversation.update!(updated_at: 1.hour.ago)
+    @conversation.envelope_for(sender: @user, recipient: @recipient)
+
+    assert_in_delta @conversation.updated_at, Time.zone.now, 1.second
+  end
 end

--- a/test/models/conversation_test.rb
+++ b/test/models/conversation_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ConversationTest < ActiveSupport::TestCase
+  def setup
+    super
+
+    @user, @recipient = create_list(:user, 2)
+
+    @conversation = create(:conversation, originator: @user,
+                                          recipient: @recipient)
+  end
+
+  def test_unread_scope_returns_unread_conversations_only
+    assert_equal 0, Conversation.unread(@user).size
+    assert_equal 1, Conversation.unread(@recipient).size
+  end
+
+  def test_mark_as_read_does_what_its_name_indicates
+    @conversation.mark_as_read(@recipient)
+
+    assert_equal 0, Conversation.unread(@user).size
+    assert_equal 0, Conversation.unread(@recipient).size
+  end
+
+  def test_unread_scope_excludes_deleted_conversations
+    @conversation.move_to_trash(@recipient)
+
+    assert_equal 0, Conversation.unread(@user).size
+    assert_equal 0, Conversation.unread(@recipient).size
+  end
+
+  def test_unread_method_returns_a_boolean_unread_flag
+    assert_equal false, @conversation.unread?(@user)
+    assert_equal true, @conversation.unread?(@recipient)
+  end
+end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MessageTest < ActiveSupport::TestCase
+  def setup
+    super
+
+    @user, @recipient = create_list(:user, 2)
+
+    @conversation = create(:conversation, originator: @user,
+                                          recipient: @recipient)
+  end
+
+  def test_unread_scope_returns_the_number_of_unread_messages
+    assert_equal 0, messages.unread(@user).size
+    assert_equal 1, messages.unread(@recipient).size
+
+    @conversation.envelope_for(sender: @user,
+                               recipient: @recipient,
+                               body: 'You there, buddy?')
+    @conversation.save!
+
+    assert_equal 0, messages.unread(@user).size
+    assert_equal 2, messages.unread(@recipient).size
+  end
+
+  private
+
+  def messages
+    @conversation.messages
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,46 +3,46 @@ require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
   setup do
-    @ad = FactoryGirl.create(:ad)
-    @user = FactoryGirl.create(:user, 'email' => 'jaimito@gmail.com', 'username' => 'jaimito')
-    @admin = FactoryGirl.create(:admin)
+    @ad = create(:ad)
+    @user = create(:user, 'email' => 'jaimito@gmail.com', 'username' => 'jaimito')
+    @admin = create(:admin)
   end
 
   test 'has unique usernames' do
-    user1 = FactoryGirl.build(:user, username: 'Username')
+    user1 = build(:user, username: 'Username')
     assert user1.valid?
     assert user1.save
 
-    user2 = FactoryGirl.build(:user, username: 'Username')
+    user2 = build(:user, username: 'Username')
     assert_not user2.valid?
     assert_not user2.save
     assert_includes user2.errors[:username], 'ya está en uso'
   end
 
   test 'has unique case insensitive usernames' do
-    user1 = FactoryGirl.build(:user, username: 'Username')
+    user1 = build(:user, username: 'Username')
     assert user1.valid?
     assert user1.save
 
-    user2 = FactoryGirl.build(:user, username: 'username')
+    user2 = build(:user, username: 'username')
     assert_not user2.valid?
     assert_not user2.save
     assert_includes user2.errors[:username], 'ya está en uso'
   end
 
   test 'has unique emails' do
-    user1 = FactoryGirl.build(:user, email: 'larryfoster@example.com')
+    user1 = build(:user, email: 'larryfoster@example.com')
     assert user1.valid?
     assert user1.save
 
-    user2 = FactoryGirl.build(:user, email: 'larryfoster@example.com')
+    user2 = build(:user, email: 'larryfoster@example.com')
     assert_not user2.valid?
     assert_not user2.save
     assert_includes user2.errors[:email], 'ya está en uso'
   end
 
   test 'saves downcased emails' do
-    user1 = FactoryGirl.build(:user, email: 'Larryfoster@example.com')
+    user1 = build(:user, email: 'Larryfoster@example.com')
     assert user1.valid?
     assert user1.save
     assert_equal 'larryfoster@example.com', user1.email
@@ -98,18 +98,18 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'requires confirmation for new users' do
-    user = FactoryGirl.create(:non_confirmed_user)
+    user = create(:non_confirmed_user)
     assert_equal(user.active_for_authentication?, false)
   end
 
   test 'associated ads are deleted when user is deleted' do
-    FactoryGirl.create(:ad, user: @user)
+    create(:ad, user: @user)
 
     assert_difference(-> { Ad.count }, -1) { @user.destroy }
   end
 
   test 'associated comments are deleted when user is deleted' do
-    FactoryGirl.create(:comment, user: @user)
+    create(:comment, user: @user)
 
     assert_difference(-> { Comment.count }, -1) { @user.destroy }
   end
@@ -117,12 +117,12 @@ end
 
 class UserScopesTest < ActiveSupport::TestCase
   setup do
-    3.times { FactoryGirl.create(:ad, user: user1) }
-    2.times { FactoryGirl.create(:ad, user: user2) }
+    3.times { create(:ad, user: user1) }
+    2.times { create(:ad, user: user2) }
   end
 
   test 'top overall ignores wanted ads from counts and results' do
-    FactoryGirl.create(:ad, user: user3, type: 2)
+    create(:ad, user: user3, type: 2)
     user2.ads.last.update(type: 2)
 
     results = User.top_overall
@@ -133,7 +133,7 @@ class UserScopesTest < ActiveSupport::TestCase
   end
 
   test 'top overall gives all time top ad publishers' do
-    FactoryGirl.create(:ad, user: user3)
+    create(:ad, user: user3)
 
     results = User.top_overall
 
@@ -144,7 +144,7 @@ class UserScopesTest < ActiveSupport::TestCase
   end
 
   test "top last week gives last week's top publishers" do
-    FactoryGirl.create(:ad, user: user3, published_at: 8.days.ago)
+    create(:ad, user: user3, published_at: 8.days.ago)
 
     results = User.top_last_week
 
@@ -169,14 +169,14 @@ class UserScopesTest < ActiveSupport::TestCase
   end
 
   def user1
-    @user1 ||= FactoryGirl.create(:user, username: 'user1')
+    @user1 ||= create(:user, username: 'user1')
   end
 
   def user2
-    @user2 ||= FactoryGirl.create(:user, username: 'user2')
+    @user2 ||= create(:user, username: 'user2')
   end
 
   def user3
-    @user3 ||= FactoryGirl.create(:user, username: 'user3')
+    @user3 ||= create(:user, username: 'user3')
   end
 end


### PR DESCRIPTION
Como a la PR de bloqueos le queda aún un pelín para aterrizar en master he extraído de ella algunos cambios que ya pueden ser mergeados.

Esto tiene 2 ventajas. Por un lado reducimos la complejidad de la PR de bloqueos, y por otro permitimos ciertas cosas puedan llegar a master sin tener que esperar a que toda la PR esté lista.

En particular, esto arregla un bug introducido recientemente en las conversaciones por el cual el timestamp de las mismas no se actualiza bien al responder, y por tanto aparecen incorrectamente ordenadas en el listado.