### PR TITLE
More fixes after blockings

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -62,7 +62,7 @@ class ConversationsController < ApplicationController
 
     @message = @conversation.envelope_for(sender: current_user,
                                           recipient: @interlocutor)
-    current_user.mark_as_read(@conversation)
+    @conversation.mark_as_read(current_user)
   end
 
   def trash
@@ -86,6 +86,6 @@ class ConversationsController < ApplicationController
   end
 
   def conversations
-    current_user.conversations
+    Conversation.involving(current_user)
   end
 end

--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -23,8 +23,8 @@ class Ad < ActiveRecord::Base
 
   require 'ipaddress'
 
-  belongs_to :user, foreign_key: 'user_owner', counter_cache: true
-  has_many :comments, foreign_key: 'ads_id', dependent: :destroy
+  belongs_to :user, foreign_key: :user_owner, counter_cache: true
+  has_many :comments, foreign_key: :ads_id, dependent: :destroy
 
   validates :title, presence: true, length: { minimum: 4, maximum: 100 }
   validates :body, presence: true, length: { minimum: 25, maximum: 1000 }

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,8 +2,8 @@
 class Comment < ActiveRecord::Base
   include Hidable
 
-  belongs_to :user, foreign_key: 'user_owner'
-  belongs_to :ad, foreign_key: 'ads_id'
+  belongs_to :user, foreign_key: :user_owner
+  belongs_to :ad, foreign_key: :ads_id
 
   validates :ads_id, presence: true
   validates :body, presence: true

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -3,7 +3,7 @@
 class Conversation < ActiveRecord::Base
   validates :subject, presence: true, length: { maximum: 255 }
 
-  has_many :messages
+  has_many :messages, dependent: :destroy
   has_many :receipts, through: :messages
 
   scope :involving, ->(user) do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,9 +10,7 @@ class User < ActiveRecord::Base
 
   has_many :receipts, foreign_key: :receiver_id
 
-  has_many :blockings, class_name: 'Blocking',
-                       foreign_key: :blocker_id,
-                       dependent: :destroy
+  has_many :blockings, foreign_key: :blocker_id, dependent: :destroy
 
   before_save :default_lang
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,8 @@
 class User < ActiveRecord::Base
   has_many :identities, inverse_of: :user, dependent: :destroy
 
-  has_many :ads, foreign_key: 'user_owner', dependent: :destroy
-  has_many :comments, foreign_key: 'user_owner', dependent: :destroy
+  has_many :ads, foreign_key: :user_owner, dependent: :destroy
+  has_many :comments, foreign_key: :user_owner, dependent: :destroy
 
   has_many :friendships
   has_many :friends, through: :friendships
@@ -11,7 +11,7 @@ class User < ActiveRecord::Base
   has_many :receipts, as: :receiver, dependent: :destroy
 
   has_many :blockings, class_name: 'Blocking',
-                       foreign_key: 'blocker_id',
+                       foreign_key: :blocker_id,
                        dependent: :destroy
 
   before_save :default_lang

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ActiveRecord::Base
   has_many :friendships
   has_many :friends, through: :friendships
 
-  has_many :receipts, as: :receiver
+  has_many :receipts, foreign_key: :receiver_id
 
   has_many :blockings, class_name: 'Blocking',
                        foreign_key: :blocker_id,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ActiveRecord::Base
   has_many :friendships
   has_many :friends, through: :friendships
 
-  has_many :receipts, as: :receiver, dependent: :destroy
+  has_many :receipts, as: :receiver
 
   has_many :blockings, class_name: 'Blocking',
                        foreign_key: :blocker_id,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,16 +81,8 @@ class User < ActiveRecord::Base
     email
   end
 
-  def conversations
-    @conversations ||= Conversation.involving(self)
-  end
-
   def unread_conversations_count
-    conversations.unread(self).size
-  end
-
-  def mark_as_read(conversation)
-    conversation.mark_as_read(self)
+    Conversation.unread(self).size
   end
 
   def admin?

--- a/app/policies/conversation_policy.rb
+++ b/app/policies/conversation_policy.rb
@@ -1,18 +1,24 @@
 # frozen_string_literal: true
 class ConversationPolicy < ApplicationPolicy
   def create?
-    user && user == sender && no_blockings?
+    sender && recipient && user == sender && no_blockings?
   end
 
   def update?
-    user && user == sender && no_blockings?
+    sender && recipient && user == sender && no_blockings?
   end
 
   def show?
-    record.interlocutor(user).whitelisting?(user)
+    return true unless interlocutor
+
+    interlocutor.whitelisting?(user)
   end
 
   private
+
+  def interlocutor
+    @interlocutor ||= record.interlocutor(user)
+  end
 
   def no_blockings?
     Blocking.none_between?(sender, recipient)

--- a/app/views/mailboxer/message_mailer/new_message_email.html.erb
+++ b/app/views/mailboxer/message_mailer/new_message_email.html.erb
@@ -5,7 +5,7 @@
 <b><%= I18n.t("mailboxer.message_mailer.message.subject") %></b>
 <blockquote>
   <p>
-  <%= @message.subject %>
+  <%= @message.conversation.subject %>
   </p>
 </blockquote>
 

--- a/app/views/mailboxer/message_mailer/new_message_email.text.erb
+++ b/app/views/mailboxer/message_mailer/new_message_email.text.erb
@@ -3,7 +3,7 @@
 
 -----------------------------------------------
 <%= I18n.t("mailboxer.message_mailer.message.subject") %>:
-<%= @message.subject %>
+<%= @message.conversation.subject %>
 
 <%= I18n.t("mailboxer.message_mailer.message.body") %>:
 <%= @message.body %>

--- a/db/migrate/20160816012524_remove_unused_messaging_columns.rb
+++ b/db/migrate/20160816012524_remove_unused_messaging_columns.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class RemoveUnusedMessagingColumns < ActiveRecord::Migration
+  def change
+    remove_column :messages, :sender_type, :string
+
+    rename_index :messages,
+                 :index_messages_on_sender_id_and_sender_type,
+                 :index_messages_on_sender_id
+
+    remove_column :messages, :notified_object_type, :string
+    remove_column :messages, :notified_object_id, :integer
+
+    remove_column :receipts, :receiver_type, :string
+
+    rename_index :receipts,
+                 :index_receipts_on_receiver_id_and_receiver_type,
+                 :index_receipts_on_receiver_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160807150239) do
+ActiveRecord::Schema.define(version: 20160816012524) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace",     limit: 255
@@ -110,29 +110,24 @@ ActiveRecord::Schema.define(version: 20160807150239) do
   add_index "identities", ["user_id"], name: "index_identities_on_user_id", using: :btree
 
   create_table "messages", force: :cascade do |t|
-    t.text     "body",                 limit: 16777215
-    t.string   "subject",              limit: 255,      default: ""
-    t.integer  "sender_id",            limit: 4
-    t.string   "sender_type",          limit: 255
-    t.integer  "conversation_id",      limit: 4
-    t.boolean  "draft",                                 default: false
-    t.datetime "updated_at",                                            null: false
-    t.datetime "created_at",                                            null: false
-    t.integer  "notified_object_id",   limit: 4
-    t.string   "notified_object_type", limit: 255
-    t.string   "notification_code",    limit: 255
-    t.string   "attachment",           limit: 255
-    t.boolean  "global",                                default: false
+    t.text     "body",              limit: 16777215
+    t.string   "subject",           limit: 255,      default: ""
+    t.integer  "sender_id",         limit: 4
+    t.integer  "conversation_id",   limit: 4
+    t.boolean  "draft",                              default: false
+    t.datetime "updated_at",                                         null: false
+    t.datetime "created_at",                                         null: false
+    t.string   "notification_code", limit: 255
+    t.string   "attachment",        limit: 255
+    t.boolean  "global",                             default: false
     t.datetime "expires"
   end
 
   add_index "messages", ["conversation_id"], name: "index_messages_on_conversation_id", using: :btree
-  add_index "messages", ["notified_object_id", "notified_object_type"], name: "index_messages_on_notified_object_id_and_type", using: :btree
-  add_index "messages", ["sender_id", "sender_type"], name: "index_messages_on_sender_id_and_sender_type", using: :btree
+  add_index "messages", ["sender_id"], name: "index_messages_on_sender_id", using: :btree
 
   create_table "receipts", force: :cascade do |t|
     t.integer  "receiver_id",     limit: 4
-    t.string   "receiver_type",   limit: 255
     t.integer  "notification_id", limit: 4,                   null: false
     t.boolean  "is_read",                     default: false
     t.boolean  "trashed",                     default: false
@@ -145,7 +140,7 @@ ActiveRecord::Schema.define(version: 20160807150239) do
   end
 
   add_index "receipts", ["notification_id"], name: "index_receipts_on_notification_id", using: :btree
-  add_index "receipts", ["receiver_id", "receiver_type"], name: "index_receipts_on_receiver_id_and_receiver_type", using: :btree
+  add_index "receipts", ["receiver_id"], name: "index_receipts_on_receiver_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "username",               limit: 63,               null: false

--- a/lib/tasks/conversations.rake
+++ b/lib/tasks/conversations.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :conversations do
+  desc 'Deletes orphan conversations'
+  task remove_orphan: :environment do
+    Conversation.joins(:receipts)
+                .group(:id)
+                .select(:id, 'count(*) as n_receipts')
+                .having('n_receipts <= 1')
+                .destroy_all
+  end
+end

--- a/test/integration/concerns/standard_messages.rb
+++ b/test/integration/concerns/standard_messages.rb
@@ -77,8 +77,12 @@ module StandardMessages
   def test_just_shows_a_special_label_when_the_interlocutor_is_no_longer_there
     send_message(subject: 'Cosas', body: 'hola, user2')
     @user2.destroy
-    visit conversations_path
 
+    visit conversations_path
+    assert_content '[borrado]'
+    refute_link '[borrado]'
+
+    visit conversation_path(Conversation.first)
     assert_content '[borrado]'
     refute_link '[borrado]'
   end


### PR DESCRIPTION
Otra PR de arreglos de pequeños bugs introducidos tras los bloqueos.

* Arregla un crash detectado en errbit al mostrar conversaciones "huérfanas" con usuarios eliminados.
* Arregla un bug por el cuál las conversaciones "huérfanas" generadas reciéntemente no se estarían mostrando en los listados, pero las antiguas sí.