### PR TITLE
Restore home page caching

### DIFF
--- a/app/controllers/ads_controller.rb
+++ b/app/controllers/ads_controller.rb
@@ -10,7 +10,9 @@ class AdsController < ApplicationController
       url = current_user.woeid? ? ads_woeid_path(id: current_user.woeid, type: 'give') : location_ask_path
       redirect_to url
     else
-      @ads = Ad.give.available.includes(:user).paginate(page: params[:page])
+      @ads = Rails.cache.fetch("ads_list_#{params[:page]}") do
+        Ad.give.available.includes(:user).paginate(page: params[:page])
+      end
     end
   end
 


### PR DESCRIPTION
Vuelvo a añadir el caching en la home page.

@andreslucena tenías razón al cuestionar esto. Hemos tenido algunos problemas en el servidor y la verdad no estoy seguro de que este sea el motivo, pero mejor añadirlo de vuelta al menos hasta que tengamos una herramienta de monitorización de la performance en producción configurada.