### PR TITLE
Switch locales in a separate controller

### DIFF
--- a/app/controllers/concerns/multi_lingualizable.rb
+++ b/app/controllers/concerns/multi_lingualizable.rb
@@ -13,16 +13,8 @@ module MultiLingualizable
   end
 
   def set_locale
-    cookies.permanent[:locale] = params[:lang] if valid_locale?(params[:lang])
-
     I18n.locale =
       params_locale || cookie_locale || browser_locale || default_locale
-  end
-
-  def valid_locale?(code)
-    return false unless code.present?
-
-    I18n.available_locales.include?(code.to_sym)
   end
 
   def params_locale

--- a/app/controllers/locales_controller.rb
+++ b/app/controllers/locales_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class LocalesController < ApplicationController
+  def show
+    if valid_locale?(locale)
+      cookies.permanent[:locale] = locale
+
+      redirect_to refered_url
+    else
+      redirect_to referer_url
+    end
+  end
+
+  private
+
+  def referer_url
+    URI.parse(request.referer || root_path)
+  end
+
+  def refered_url
+    @refered_url = referer_url
+    @refered_url.path = refered_path
+    @refered_url.query = referer_url.query
+    @refered_url.to_s
+  end
+
+  def referer_path
+    referer_url.path
+  end
+
+  def refered_path
+    return "/#{locale}" if referer_path.empty?
+
+    segments = referer_path.split('/')
+    segments[1] = locale if valid_locale?(segments[1])
+    segments.join('/')
+  end
+
+  def valid_locale?(locale)
+    return false unless locale.present?
+
+    I18n.available_locales.include?(locale.to_sym)
+  end
+
+  def locale
+    params[:locale]
+  end
+end

--- a/app/views/partials/_language.html.erb
+++ b/app/views/partials/_language.html.erb
@@ -1,5 +1,7 @@
 <% is_active_class = I18n.locale == abbr.to_sym ? "active" : "''" %>
 
-<%= link_to params.merge({locale: nil, lang: abbr}), class: "flag-#{ abbr }  lang #{is_active_class}", "data-langcode" => abbr do %>
+<%= link_to locale_path(abbr),
+            class: "flag-#{abbr} lang #{is_active_class}",
+            "data-langcode" => abbr do %>
   <span><%= language %></span>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ NolotiroOrg::Application.routes.draw do
 
   devise_for :users, only: :omniauth_callbacks, controllers: { omniauth_callbacks: 'callbacks' }
 
+  get '/locales/:locale', to: 'locales#show', as: :locale
+
   # i18n
   scope '(:locale)', locale: /#{I18n.available_locales.join("|")}/ do
     root 'ads#index'


### PR DESCRIPTION
* Google doesn't like the `lang` parameter because it can't find return
hreflang urls for urls with that parameter.
* We don't need to set a cookie for every action.
* We get cleaner URLs this way.

La idea es cambiar de locale de una forma más limpia que espero le guste más a google.