### PR TITLE
Disallow bad usernames

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,7 +381,7 @@ GEM
       sexp_processor (~> 4.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
-    sass-rails (5.0.5)
+    sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,9 +29,11 @@ class User < ActiveRecord::Base
 
   before_save :default_lang
 
-  validates :username, presence: true,
-                       uniqueness: { case_sensitive: false },
-                       length: { maximum: 63 }
+  validates :username, presence: true
+  validates :username, uniqueness: { case_sensitive: false },
+                       length: { maximum: 63 },
+                       allow_blank: true,
+                       if: :username_changed?
 
   validates :email, presence: true
   validates :email, uniqueness: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,7 @@ class User < ActiveRecord::Base
 
   validates :username, presence: true
   validates :username, uniqueness: { case_sensitive: false },
+                       format: { without: /\A[^@]+@[^@]+\z/ },
                        length: { maximum: 63 },
                        allow_blank: true,
                        if: :username_changed?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ActiveRecord::Base
 
   validates :username, presence: true
   validates :username, uniqueness: { case_sensitive: false },
-                       format: { without: /\A[^@]+@[^@]+\z/ },
+                       format: { without: /\A([^@]+@[^@]+|[1-9]+)\z/ },
                        length: { maximum: 63 },
                        allow_blank: true,
                        if: :username_changed?

--- a/app/views/devise/mailer/reset_password_instructions.text.erb
+++ b/app/views/devise/mailer/reset_password_instructions.text.erb
@@ -3,8 +3,8 @@
 <%= t('devise.passwords.follow_instructions') %>
 
 <%= link_to t('devise.passwords.action'),
-            edit_password_url(@resource, :reset_password_token => @token) %>
+            edit_password_url(@resource, reset_password_token: @token) %>
 
 <%= t('devise.passwords.no_html_instructions') %>
 
-<%= edit_password_url(@resource, :reset_password_token => @token) %>
+<%= edit_password_url(@resource, reset_password_token: @token) %>

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -80,7 +80,7 @@ NolotiroOrg::Application.configure do
 
   # for mailcatcher
   # config.action_mailer.delivery_method = :smtp
-  # config.action_mailer.smtp_settings = { :address => "127.0.0.1", :port => 1025 }
+  # config.action_mailer.smtp_settings = { address: "127.0.0.1", port: 1025 }
 
   # for images on mailer
   config.action_controller.asset_host = 'https://beta.nolotiro.org'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -134,16 +134,6 @@ Devise.setup do |config|
   # :secure => true in order to force SSL only cookies.
   # config.rememberable_options = {}
 
-  # ==> Configuration for :validatable
-  # Range for password length. Default is 8..128.
-  # nolotiro v2 - legacy
-  config.password_length = 5..128
-
-  # Email regex used to validate email formats. It simply asserts that
-  # one (and only one) @ exists in the given string. This is mainly
-  # to give user feedback and not to assert the e-mail validity.
-  # config.email_regexp = /\A[^@]+@[^@]+\z/
-
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -131,7 +131,7 @@ Devise.setup do |config|
   # config.extend_remember_period = false
 
   # Options to be passed to the created cookie. For instance, you can set
-  # :secure => true in order to force SSL only cookies.
+  # `secure: true` in order to force SSL only cookies.
   # config.rememberable_options = {}
 
   # ==> Configuration for :timeoutable
@@ -220,7 +220,7 @@ Devise.setup do |config|
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
-  # config.omniauth :github, 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
@@ -228,7 +228,7 @@ Devise.setup do |config|
   #
   # config.warden do |manager|
   #   manager.intercept_401 = false
-  #   manager.default_strategies(:scope => :user).unshift :some_external_strategy
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
   # end
 
   # ==> Mountable engine configurations

--- a/db/migrate/20131107202008_add_devise_to_users.rb
+++ b/db/migrate/20131107202008_add_devise_to_users.rb
@@ -7,9 +7,6 @@ class AddDeviseToUsers < ActiveRecord::Migration
 
     change_table(:users) do |t|
       ## Database authenticatable
-      #
-      # nolotiro.org v2 legacy: we already had email
-      # t.string :email,              :null => false, :default => ""
       t.string :encrypted_password, null: false, default: ''
 
       ## Recoverable
@@ -25,26 +22,10 @@ class AddDeviseToUsers < ActiveRecord::Migration
       t.datetime :last_sign_in_at
       t.string   :current_sign_in_ip
       t.string   :last_sign_in_ip
-
-      ## Confirmable
-      # t.string   :confirmation_token
-      # t.datetime :confirmed_at
-      # t.datetime :confirmation_sent_at
-      # t.string   :unconfirmed_email # Only if using reconfirmable
-
-      ## Lockable
-      # t.integer  :failed_attempts, :default => 0, :null => false # Only if lock strategy is :failed_attempts
-      # t.string   :unlock_token # Only if unlock strategy is :email or :both
-      # t.datetime :locked_at
-
-      # Uncomment below if timestamps were not included in your original model.
-      # t.timestamps
     end
 
     add_index :users, :email,                unique: true
     add_index :users, :reset_password_token, unique: true
-    # add_index :users, :confirmation_token,   :unique => true
-    # add_index :users, :unlock_token,         :unique => true
   end
 
   def down

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -20,4 +20,16 @@ namespace :users do
       user.update!(username: new_username)
     end
   end
+
+  desc 'Renames users with id-like usernames'
+  task remove_id_like_usernames: :environment do
+    target = User.where("username REGEXP '^[1-9]+$'")
+
+    STDOUT.print "About to rename #{target.size} users. Continue? (y/n)"
+    abort unless STDIN.gets.chomp == 'y'
+
+    target.find_each do |user|
+      user.update!(username: user.email.gsub(/@.*/, '') + user.username)
+    end
+  end
 end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+namespace :users do
+  desc 'Renames users with email-like usernames'
+  task remove_email_like_usernames: :environment do
+    target = User.where("username REGEXP '[^@]+@[^@]+'")
+
+    STDOUT.print "About to rename #{target.size} users. Continue? (y/n)"
+    abort unless STDIN.gets.chomp == 'y'
+
+    target.find_each do |user|
+      sanitized_username = user.username.gsub(/@.*/, '')
+
+      new_username = if User.exists?(username: sanitized_username)
+                       sanitized_username + '0'
+                     else
+                       sanitized_username
+                     end
+
+      user.update!(username: new_username)
+    end
+  end
+end

--- a/test/controllers/conversations_controller.rb
+++ b/test/controllers/conversations_controller.rb
@@ -6,8 +6,8 @@ class ConversationsControllerTest < ActionController::TestCase
 
   setup do
     @ad = create(:ad)
-    @user1 = create(:user, 'email' => 'davidbowie@gmail.com', 'username' => 'davidbowie')
-    @user2 = create(:user, 'email' => 'marcbolan@gmail.com', 'username' => 'trex')
+    @user1 = create(:user, email: 'davidbowie@gmail.com', username: 'davidbowie')
+    @user2 = create(:user, email: 'marcbolan@gmail.com', username: 'trex')
   end
 
   test 'should redirect to signup to create a message as anon' do
@@ -57,7 +57,7 @@ class ConversationsControllerTest < ActionController::TestCase
     end
     m = Conversation.last
     sign_out @user1
-    user3 = create(:user, 'email' => 'brianeno@gmail.com', 'username' => 'eno')
+    user3 = create(:user, email: 'brianeno@gmail.com', username: 'eno')
     sign_in user3
     get :show, id: m.id
     assert_equal 'No tienes permisos para realizar esta acción.', flash[:alert]

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -6,7 +6,7 @@ class UsersControllerTest < ActionController::TestCase
 
   setup do
     @ad = create(:ad)
-    @user = create(:user, 'email' => 'jaimito@gmail.com', 'username' => 'jaimito')
+    @user = create(:user, email: 'jaimito@gmail.com', username: 'jaimito')
   end
 
   test 'should get user profile by username' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class UserTest < ActiveSupport::TestCase
   setup do
     @ad = create(:ad)
-    @user = create(:user, 'email' => 'jaimito@gmail.com', 'username' => 'jaimito')
+    @user = create(:user, email: 'jaimito@gmail.com', username: 'jaimito')
     @admin = create(:admin)
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -38,6 +38,17 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user.errors[:username], 'no es válido'
   end
 
+  test 'disallows usernames that look like ids' do
+    user1 = build(:user, username: '007')
+    assert user1.valid?
+    assert user1.save
+
+    user2 = build(:user, username: '12345')
+    assert_not user2.valid?
+    assert_not user2.save
+    assert_includes user2.errors[:username], 'no es válido'
+  end
+
   test 'has unique emails' do
     user1 = build(:user, email: 'larryfoster@example.com')
     assert user1.valid?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -30,6 +30,14 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user2.errors[:username], 'ya está en uso'
   end
 
+  test 'disallows usernames that look like emails' do
+    user = build(:user, username: 'larryfoster@example.com')
+
+    assert_not user.valid?
+    assert_not user.save
+    assert_includes user.errors[:username], 'no es válido'
+  end
+
   test 'has unique emails' do
     user1 = build(:user, email: 'larryfoster@example.com')
     assert user1.valid?


### PR DESCRIPTION
Supersedes #397.

Aumenta el scope de la PR anterior. Ahora la PR hace dos cosas:

* Eliminar nombres de usuario con forma de emails. No queremos que las usuarias hagan su email público con este "truco".

* Eliminar nombres de usuarios que pueden colisionar con ids. No queremos que las URLs de perfil con ids y usernames colisionen.