### PR TITLE
Show all ads in all tab

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ rvm:
 before_install:
   - gem update --system
   - gem install bundler
-  - sudo apt-get update
 
 script:
   - RAILS_ENV=test bin/rake db:drop db:create db:schema:load

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,12 +9,11 @@ class UsersController < ApplicationController
     @status = status_scope
 
     @ads = @user.ads
-                .includes(:user)
-                .public_send(@type)
-                .recent_first
-                .paginate(page: params[:page])
 
+    @ads = @ads.public_send(@type) if @type
     @ads = @ads.public_send(@status) if @status
+
+    @ads = @ads.includes(:user).recent_first.paginate(page: params[:page])
   end
 
   def profile
@@ -38,4 +37,12 @@ class UsersController < ApplicationController
   end
 
   helper_method :status_scope
+
+  def type_scope
+    return unless %w(give want).include?(params[:type])
+
+    params[:type]
+  end
+
+  helper_method :type_scope
 end

--- a/app/views/users/_filter_status.html.erb
+++ b/app/views/users/_filter_status.html.erb
@@ -1,8 +1,7 @@
 <div class="filter_status">
   <!-- TODO: Once #213 is fixed we can simplify some checks here -->
 
-  <%= link_to t('nlt.all'), url_for(type: 'give'),
-    class: type_scope == "give" && status_scope.nil? ? "actual" : "''" %>
+  <%= link_to t('nlt.all'), url_for, class: type_scope.nil? ? "actual" : "''" %>
 
   <%= link_to t('nlt.available'), url_for(type: 'give', status: 'available'),
     class: type_scope == "give" && status_scope == "available" ? "actual" : "''" %>

--- a/test/integration/personal_ad_listing_test.rb
+++ b/test/integration/personal_ad_listing_test.rb
@@ -27,10 +27,10 @@ class PersonalAdListing < ActionDispatch::IntegrationTest
     end
   end
 
-  it 'lists all give ads in a separate tab in user profile' do
+  it 'lists all ads in a separate tab in user profile' do
     click_link 'todos'
 
-    assert_selector '.ad_excerpt_list', count: 4
+    assert_selector '.ad_excerpt_list', count: 5
   end
 
   it 'lists wanted ads in a separate tab in user profile' do


### PR DESCRIPTION
Ahora la pestaña "Todos" del perfil del usuario muestra sólo los anuncios de regalo del usuario. Creo qué es más cómodo y más lógico que se muestre todo.