### PR TITLE
Fix all ads page regression

### DIFF
--- a/app/controllers/woeid_controller.rb
+++ b/app/controllers/woeid_controller.rb
@@ -36,6 +36,8 @@ class WoeidController < ApplicationController
   private
 
   def resolve_woeid
+    return if request.path =~ %r{/listall/}
+
     params[:id].presence || user_woeid
   end
 

--- a/app/controllers/woeid_controller.rb
+++ b/app/controllers/woeid_controller.rb
@@ -36,15 +36,13 @@ class WoeidController < ApplicationController
   private
 
   def resolve_woeid
-    return @id if @id.present?
-
-    user_woeid
+    params[:id].presence || user_woeid
   end
 
   def check_location
     redirect_to location_ask_path if user_signed_in? && user_woeid.nil?
 
-    @id = params[:id].presence || user_woeid
+    @id = resolve_woeid
   end
 
   def user_woeid

--- a/app/views/partials/_pagination.html.erb
+++ b/app/views/partials/_pagination.html.erb
@@ -1,1 +1,0 @@
-<%= will_paginate items, inner_window: 2, outer_window: -1 %>

--- a/app/views/users/listads.html.erb
+++ b/app/views/users/listads.html.erb
@@ -13,7 +13,7 @@
     <% if @ads.any? %>
       <%= render 'ads/list_with_adsense', ads: @ads %>
 
-      <%= render "partials/pagination", items: @ads %>
+      <%= will_paginate @ads, inner_window: 2, outer_window: -1 %>
     <% else %>
       <div class="empty"> <%= t("nlt.no_results.on_user") %> </div>
     <% end %>

--- a/app/views/woeid/show.html.erb
+++ b/app/views/woeid/show.html.erb
@@ -74,7 +74,9 @@
   <% if @ads.any? %>
     <%= render 'ads/list_with_adsense', ads: @ads %>
 
-    <%= will_paginate @ads, inner_window: 2, outer_window: -1 %>
+    <%= will_paginate @ads, params: params.merge(id: @id),
+                            inner_window: 2,
+                            outer_window: -1 %>
   <% else %>
     <% if @q %>
       <%= render "ads/no_results_search" %>

--- a/app/views/woeid/show.html.erb
+++ b/app/views/woeid/show.html.erb
@@ -74,7 +74,7 @@
   <% if @ads.any? %>
     <%= render 'ads/list_with_adsense', ads: @ads %>
 
-    <%= render "partials/pagination", items: @ads %>
+    <%= will_paginate @ads, inner_window: 2, outer_window: -1 %>
   <% else %>
     <% if @q %>
       <%= render "ads/no_results_search" %>

--- a/test/fixtures/vcr_cassettes/mad_bar_ten_info_es.yml
+++ b/test/fixtures/vcr_cassettes/mad_bar_ten_info_es.yml
@@ -1,0 +1,215 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://query.yahooapis.com/v1/public/yql?format=json&q=select%20*%20from%20geo.places%20where%20woeid%20=%20766273%20AND%20lang%20=%20%27es%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      Host:
+      - query.yahooapis.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Yql-Host:
+      - prod_bf1_1;paas.yql;queryyahooapiscomproductionbf1;d4055e35-75e9-11e6-a2c9-d4ae52974741
+      X-Content-Type-Options:
+      - nosniff
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Cache-Control:
+      - no-cache
+      Date:
+      - Fri, 16 Sep 2016 23:29:45 GMT
+      Age:
+      - '0'
+      Server:
+      - ATS
+      Via:
+      - http/1.1 a08.ue.bf1.yahoo.net (ApacheTrafficServer [cMsSf ])
+      Y-Trace:
+      - BAEAQAAAAACjLfj_SBNGkQAAAAAAAAAAwmzerxTUl6AAAAAAAAAAAAAFPKhWYs_RAAU8qFZi.9Q4yPUAAAAAAA--
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJxdWVyeSI6eyJjb3VudCI6MSwiY3JlYXRlZCI6IjIwMTYtMDktMTZUMjM6
+        Mjk6NDVaIiwibGFuZyI6ImVuLVVTIiwicmVzdWx0cyI6eyJwbGFjZSI6eyJs
+        YW5nIjoiZXMtIiwieG1sbnMiOiJodHRwOi8vd2hlcmUueWFob29hcGlzLmNv
+        bS92MS9zY2hlbWEucm5nIiwieWFob28iOiJodHRwOi8vd3d3LnlhaG9vYXBp
+        cy5jb20vdjEvYmFzZS5ybmciLCJ1cmkiOiJodHRwOi8vd2hlcmUueWFob29h
+        cGlzLmNvbS92MS9wbGFjZS83NjYyNzMiLCJ3b2VpZCI6Ijc2NjI3MyIsInBs
+        YWNlVHlwZU5hbWUiOnsiY29kZSI6IjciLCJjb250ZW50IjoiUHVlYmxvIn0s
+        Im5hbWUiOiJNYWRyaWQiLCJjb3VudHJ5Ijp7ImNvZGUiOiJFUyIsInR5cGUi
+        OiJQYcOtcyIsIndvZWlkIjoiMjM0MjQ5NTAiLCJjb250ZW50IjoiRXNwYcOx
+        YSJ9LCJhZG1pbjEiOnsiY29kZSI6IiIsInR5cGUiOiJDb211bmlkYWQgQXV0
+        w7Nub21hIiwid29laWQiOiIxMjU3ODAyNCIsImNvbnRlbnQiOiJNYWRyaWQi
+        fSwiYWRtaW4yIjp7ImNvZGUiOiIiLCJ0eXBlIjoiQ29uZGFkbyIsIndvZWlk
+        IjoiMTI2MDIwOTAiLCJjb250ZW50IjoiTWFkcmlkIn0sImFkbWluMyI6bnVs
+        bCwibG9jYWxpdHkxIjp7InR5cGUiOiJQdWVibG8iLCJ3b2VpZCI6Ijc2NjI3
+        MyIsImNvbnRlbnQiOiJNYWRyaWQifSwibG9jYWxpdHkyIjpudWxsLCJwb3N0
+        YWwiOm51bGwsImNlbnRyb2lkIjp7ImxhdGl0dWRlIjoiNDAuNDIxNDI5Iiwi
+        bG9uZ2l0dWRlIjoiLTMuNjcxNjMifSwiYm91bmRpbmdCb3giOnsic291dGhX
+        ZXN0Ijp7ImxhdGl0dWRlIjoiNDAuMzI1OTM5IiwibG9uZ2l0dWRlIjoiLTMu
+        Nzk4ODcifSwibm9ydGhFYXN0Ijp7ImxhdGl0dWRlIjoiNDAuNTIwMDgxIiwi
+        bG9uZ2l0dWRlIjoiLTMuNTM0OSJ9fSwiYXJlYVJhbmsiOiIxIiwicG9wUmFu
+        ayI6IjEiLCJ0aW1lem9uZSI6eyJ0eXBlIjoiVGltZSBab25lIiwid29laWQi
+        OiI1NjA0MzY0NCIsImNvbnRlbnQiOiJFdXJvcGUvTWFkcmlkIn19fX19
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 23:29:45 GMT
+- request:
+    method: get
+    uri: http://query.yahooapis.com/v1/public/yql?format=json&q=select%20*%20from%20geo.places%20where%20woeid%20=%20753692%20AND%20lang%20=%20%27es%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      Host:
+      - query.yahooapis.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Yql-Host:
+      - prod_bf1_1;paas.yql;queryyahooapiscomproductionbf1;2415e453-76a3-11e6-a2c9-d4ae52974741
+      X-Content-Type-Options:
+      - nosniff
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Cache-Control:
+      - no-cache
+      Date:
+      - Fri, 16 Sep 2016 23:29:46 GMT
+      Age:
+      - '0'
+      Server:
+      - ATS
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJxdWVyeSI6eyJjb3VudCI6MSwiY3JlYXRlZCI6IjIwMTYtMDktMTZUMjM6
+        Mjk6NDZaIiwibGFuZyI6ImVuLVVTIiwicmVzdWx0cyI6eyJwbGFjZSI6eyJs
+        YW5nIjoiZXMtIiwieG1sbnMiOiJodHRwOi8vd2hlcmUueWFob29hcGlzLmNv
+        bS92MS9zY2hlbWEucm5nIiwieWFob28iOiJodHRwOi8vd3d3LnlhaG9vYXBp
+        cy5jb20vdjEvYmFzZS5ybmciLCJ1cmkiOiJodHRwOi8vd2hlcmUueWFob29h
+        cGlzLmNvbS92MS9wbGFjZS83NTM2OTIiLCJ3b2VpZCI6Ijc1MzY5MiIsInBs
+        YWNlVHlwZU5hbWUiOnsiY29kZSI6IjciLCJjb250ZW50IjoiUHVlYmxvIn0s
+        Im5hbWUiOiJCYXJjZWxvbmEiLCJjb3VudHJ5Ijp7ImNvZGUiOiJFUyIsInR5
+        cGUiOiJQYcOtcyIsIndvZWlkIjoiMjM0MjQ5NTAiLCJjb250ZW50IjoiRXNw
+        YcOxYSJ9LCJhZG1pbjEiOnsiY29kZSI6IiIsInR5cGUiOiJDb211bmlkYWQg
+        QXV0w7Nub21hIiwid29laWQiOiIxMjU3ODAzNCIsImNvbnRlbnQiOiJDYXRh
+        bHXDsWEifSwiYWRtaW4yIjp7ImNvZGUiOiIiLCJ0eXBlIjoiQ29uZGFkbyIs
+        IndvZWlkIjoiMTI2MDIxMjQiLCJjb250ZW50IjoiQmFyY2Vsb25hIn0sImFk
+        bWluMyI6bnVsbCwibG9jYWxpdHkxIjp7InR5cGUiOiJQdWVibG8iLCJ3b2Vp
+        ZCI6Ijc1MzY5MiIsImNvbnRlbnQiOiJCYXJjZWxvbmEifSwibG9jYWxpdHky
+        IjpudWxsLCJwb3N0YWwiOm51bGwsImNlbnRyb2lkIjp7ImxhdGl0dWRlIjoi
+        NDEuMzk5MTciLCJsb25naXR1ZGUiOiIyLjE1Mzk3In0sImJvdW5kaW5nQm94
+        Ijp7InNvdXRoV2VzdCI6eyJsYXRpdHVkZSI6IjQxLjMyMTA2IiwibG9uZ2l0
+        dWRlIjoiMi4wNzE5MiJ9LCJub3J0aEVhc3QiOnsibGF0aXR1ZGUiOiI0MS40
+        Njg2MDkiLCJsb25naXR1ZGUiOiIyLjIyNzMxIn19LCJhcmVhUmFuayI6IjEi
+        LCJwb3BSYW5rIjoiMSIsInRpbWV6b25lIjp7InR5cGUiOiJUaW1lIFpvbmUi
+        LCJ3b2VpZCI6IjU2MDQzNjQ0IiwiY29udGVudCI6IkV1cm9wZS9NYWRyaWQi
+        fX19fX0=
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 23:29:46 GMT
+- request:
+    method: get
+    uri: http://query.yahooapis.com/v1/public/yql?format=json&q=select%20*%20from%20geo.places%20where%20woeid%20=%20773692%20AND%20lang%20=%20%27es%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      Host:
+      - query.yahooapis.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Yql-Host:
+      - prod_bf1_1;paas.yql;queryyahooapiscomproductionbf1;d41abb27-75e9-11e6-a2c9-d4ae52974741
+      X-Content-Type-Options:
+      - nosniff
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Cache-Control:
+      - no-cache
+      Date:
+      - Fri, 16 Sep 2016 23:29:47 GMT
+      Age:
+      - '0'
+      Server:
+      - ATS
+      Via:
+      - http/1.1 a24.ue.bf1.yahoo.net (ApacheTrafficServer [cMsSf ])
+      Y-Trace:
+      - BAEAQAAAAACLlsh3sU_u7AAAAAAAAAAAC6YVzq5n6Z0AAAAAAAAAAAAFPKhWhNjFAAU8qFaFEgc7Z.qEAAAAAA--
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJxdWVyeSI6eyJjb3VudCI6MSwiY3JlYXRlZCI6IjIwMTYtMDktMTZUMjM6
+        Mjk6NDdaIiwibGFuZyI6ImVuLVVTIiwicmVzdWx0cyI6eyJwbGFjZSI6eyJs
+        YW5nIjoiZXMtIiwieG1sbnMiOiJodHRwOi8vd2hlcmUueWFob29hcGlzLmNv
+        bS92MS9zY2hlbWEucm5nIiwieWFob28iOiJodHRwOi8vd3d3LnlhaG9vYXBp
+        cy5jb20vdjEvYmFzZS5ybmciLCJ1cmkiOiJodHRwOi8vd2hlcmUueWFob29h
+        cGlzLmNvbS92MS9wbGFjZS83NzM2OTIiLCJ3b2VpZCI6Ijc3MzY5MiIsInBs
+        YWNlVHlwZU5hbWUiOnsiY29kZSI6IjciLCJjb250ZW50IjoiUHVlYmxvIn0s
+        Im5hbWUiOiJTYW50YSBDcnV6IGRlIFRlbmVyaWZlIiwiY291bnRyeSI6eyJj
+        b2RlIjoiRVMiLCJ0eXBlIjoiUGHDrXMiLCJ3b2VpZCI6IjIzNDI0OTUwIiwi
+        Y29udGVudCI6IkVzcGHDsWEifSwiYWRtaW4xIjp7ImNvZGUiOiIiLCJ0eXBl
+        IjoiQ29tdW5pZGFkIEF1dMOzbm9tYSIsIndvZWlkIjoiMTI1NzgwMzEiLCJj
+        b250ZW50IjoiSXNsYXMgQ2FuYXJpYXMifSwiYWRtaW4yIjp7ImNvZGUiOiIi
+        LCJ0eXBlIjoiQ29uZGFkbyIsIndvZWlkIjoiMTI2MDIxMDkiLCJjb250ZW50
+        IjoiU2FudGEgQ3J1eiBkZSBUZW5lcmlmZSJ9LCJhZG1pbjMiOm51bGwsImxv
+        Y2FsaXR5MSI6eyJ0eXBlIjoiUHVlYmxvIiwid29laWQiOiI3NzM2OTIiLCJj
+        b250ZW50IjoiU2FudGEgQ3J1eiBkZSBUZW5lcmlmZSJ9LCJsb2NhbGl0eTIi
+        Om51bGwsInBvc3RhbCI6bnVsbCwiY2VudHJvaWQiOnsibGF0aXR1ZGUiOiIy
+        OC40NjE2MyIsImxvbmdpdHVkZSI6Ii0xNi4yNjcwNTkifSwiYm91bmRpbmdC
+        b3giOnsic291dGhXZXN0Ijp7ImxhdGl0dWRlIjoiMjguNDM4MDgiLCJsb25n
+        aXR1ZGUiOiItMTYuMjkxOTI5In0sIm5vcnRoRWFzdCI6eyJsYXRpdHVkZSI6
+        IjI4LjQ4Nzk0OSIsImxvbmdpdHVkZSI6Ii0xNi4yMzU1OSJ9fSwiYXJlYVJh
+        bmsiOiIxIiwicG9wUmFuayI6IjEiLCJ0aW1lem9uZSI6eyJ0eXBlIjoiVGlt
+        ZSBab25lIiwid29laWQiOiIyODM1MDg3MCIsImNvbnRlbnQiOiJBdGxhbnRp
+        Yy9DYW5hcnkifX19fX0=
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 23:29:47 GMT
+recorded_with: VCR 3.0.3

--- a/test/integration/authenticated_ad_listing_test.rb
+++ b/test/integration/authenticated_ad_listing_test.rb
@@ -11,7 +11,7 @@ class AuthenticatedAdListing < ActionDispatch::IntegrationTest
 
   around do |test|
     create(:ad, :in_mad, title: 'ava_mad1', status: 1, published_at: 1.hour.ago)
-    create(:ad, :in_bar, title: 'ava_bar', status: 1)
+    create(:ad, :in_bar, title: 'ava_bar', status: 1, published_at: 2.hours.ago)
     create(:ad, :in_mad, title: 'ava_mad2', status: 1, published_at: 1.day.ago)
     create(:ad, :in_mad, title: 'res_mad', status: 2)
     create(:ad, :in_mad, title: 'del_mad', status: 3)
@@ -19,37 +19,53 @@ class AuthenticatedAdListing < ActionDispatch::IntegrationTest
     login_as create(:user, woeid: 766_273)
 
     with_pagination(1) do
-      mocking_yahoo_woeid_info(766_273) do
-        visit root_path
-
-        test.call
-      end
+      VCR.use_cassette('mad_bar_ten_info_es') { test.call }
     end
 
     logout
   end
 
   it 'shows a link to publish ads in the users location' do
+    visit root_path
+
     assert_selector 'a', text: '+ Publicar anuncio en Madrid'
   end
 
+  it 'lists first page of available ads everywhere in all ads page' do
+    visit ads_listall_path(type: 'give')
+
+    assert_selector '.ad_excerpt_list', count: 1, text: 'ava_mad1'
+  end
+
+  it 'lists other pages of available ads everywhere in all ads page' do
+    visit ads_listall_path(type: 'give')
+    click_link 'siguiente'
+
+    assert_selector '.ad_excerpt_list', count: 1, text: 'ava_bar'
+  end
+
   it 'lists first page of available ads in users location in home page' do
+    visit root_path
+
     assert_selector '.ad_excerpt_list', count: 1, text: 'ava_mad1'
   end
 
   it 'lists other pages of available ads in users location in home page' do
+    visit root_path
     click_link 'siguiente'
 
     assert_selector '.ad_excerpt_list', count: 1, text: 'ava_mad2'
   end
 
   it 'lists reserved ads in users location in home page' do
+    visit root_path
     click_link 'reservado'
 
     assert_selector '.ad_excerpt_list', count: 1, text: 'res_mad'
   end
 
   it 'lists delivered ads in users location in home page' do
+    visit root_path
     click_link 'entregado'
 
     assert_selector '.ad_excerpt_list', count: 1, text: 'del_mad'

--- a/test/integration/unauthenticated_ad_listing_test.rb
+++ b/test/integration/unauthenticated_ad_listing_test.rb
@@ -25,6 +25,19 @@ class UnauthenticatedAdListing < ActionDispatch::IntegrationTest
     assert_select 'a', 'Ver anuncios en Mountain View'
   end
 
+  it 'lists first page of available ads everywhere in all ads page' do
+    visit ads_listall_path(type: 'give')
+
+    assert_selector '.ad_excerpt_list', count: 1, text: 'ava_mad'
+  end
+
+  it 'lists second page of available ads everywhere in all ads page' do
+    visit ads_listall_path(type: 'give')
+    click_link 'siguiente'
+
+    assert_selector '.ad_excerpt_list', count: 1, text: 'ava_bar'
+  end
+
   it 'lists first page of available ads everywhere in home page' do
     visit root_path
 

--- a/test/integration/unauthenticated_ad_listing_test.rb
+++ b/test/integration/unauthenticated_ad_listing_test.rb
@@ -15,7 +15,7 @@ class UnauthenticatedAdListing < ActionDispatch::IntegrationTest
     create(:ad, :in_ten, title: 'del_ten', status: 3)
 
     with_pagination(1) do
-      mocking_all_locations { test.call }
+      VCR.use_cassette('mad_bar_ten_info_es') { test.call }
     end
   end
 
@@ -61,15 +61,5 @@ class UnauthenticatedAdListing < ActionDispatch::IntegrationTest
 
     assert_text 'Madrid, Madrid, España'
     assert_selector '.ad_excerpt_list', count: 0
-  end
-
-  private
-
-  def mocking_all_locations
-    mocking_yahoo_woeid_info(766_273) do
-      mocking_yahoo_woeid_info(753_692) do
-        mocking_yahoo_woeid_info(773_692) { yield }
-      end
-    end
   end
 end

--- a/test/integration/unauthenticated_ad_listing_test.rb
+++ b/test/integration/unauthenticated_ad_listing_test.rb
@@ -31,14 +31,14 @@ class UnauthenticatedAdListing < ActionDispatch::IntegrationTest
     assert_selector '.ad_excerpt_list', count: 1, text: 'ava_mad'
   end
 
-  it 'lists second page of available ads everywhere in all ads page' do
+  it 'lists second page of available ads everywhere in home page' do
     visit root_path
     click_link '2'
 
     assert_selector '.ad_excerpt_list', count: 1, text: 'ava_bar'
   end
 
-  it 'lists booked ads everywhere in all ads page' do
+  it 'lists booked ads everywhere in home page' do
     visit root_path
     click_link '2'
     click_link 'reservado'
@@ -46,7 +46,7 @@ class UnauthenticatedAdListing < ActionDispatch::IntegrationTest
     assert_selector '.ad_excerpt_list', count: 1, text: 'res_mad'
   end
 
-  it 'lists delivered ads everywhere in all ads page' do
+  it 'lists delivered ads everywhere in home page' do
     visit root_path
     click_link '2'
     click_link 'entregado'

--- a/test/integration/unauthenticated_ad_listing_test.rb
+++ b/test/integration/unauthenticated_ad_listing_test.rb
@@ -33,14 +33,14 @@ class UnauthenticatedAdListing < ActionDispatch::IntegrationTest
 
   it 'lists second page of available ads everywhere in home page' do
     visit root_path
-    click_link '2'
+    click_link 'siguiente'
 
     assert_selector '.ad_excerpt_list', count: 1, text: 'ava_bar'
   end
 
   it 'lists booked ads everywhere in home page' do
     visit root_path
-    click_link '2'
+    click_link 'siguiente'
     click_link 'reservado'
 
     assert_selector '.ad_excerpt_list', count: 1, text: 'res_mad'
@@ -48,7 +48,7 @@ class UnauthenticatedAdListing < ActionDispatch::IntegrationTest
 
   it 'lists delivered ads everywhere in home page' do
     visit root_path
-    click_link '2'
+    click_link 'siguiente'
     click_link 'entregado'
 
     assert_selector '.ad_excerpt_list', count: 1, text: 'del_ten'


### PR DESCRIPTION
Tras el despliegue de las mejoras de diseño hemos introducido una regresión por la cual a un usuario logado sólo le salen anuncios de su ciudad en la página "Todos los anuncios".