### PR TITLE
Exclude search urls from google index

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,6 +53,10 @@ module ApplicationHelper
     url_for(params.merge(locale: locale, only_path: false))
   end
 
+  def canonical_url
+    url_for(params.except(:q).merge(only_path: false))
+  end
+
   def errors_for(object)
     errs = object.errors
     return unless errs.any?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
 
     <% I18n.available_locales.each do |locale| %>
       <link rel="alternate"
-            hreflang="<%= locale %>"
+            hreflang="<%= locale.to_s %>"
             href="<%= localized_url(locale) %>" />
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,8 @@
 
     <meta name='viewport' content='width=device-width, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no' />
 
+    <link rel="canonical" href="<%= canonical_url %>" />
+
     <link rel="alternate" href="<%= localized_url(nil) %>" hreflang="x-default" />
 
     <% I18n.available_locales.each do |locale| %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <title><%= yield(:meta_title) %> - nolotiro.org</title>
     <meta charset="utf-8" />
     <%= favicon_link_tag 'favicon.ico' %>
-    <%= stylesheet_link_tag    "application", media: "all" %>
+    <%= stylesheet_link_tag "application", media: "all" %>
 
     <%= csrf_meta_tags %>
 
@@ -17,7 +17,8 @@
     <meta name='viewport' content='width=device-width, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no' />
 
     <link rel="alternate" href="<%= localized_url(nil) %>" hreflang="x-default" />
-    <% I18n.available_locales.each do |l|  %>
+
+    <% I18n.available_locales.each do |l| %>
       <link rel="alternate" hreflang="<%= l %>" href="<%= localized_url(l) %>" />
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,8 +18,10 @@
 
     <link rel="alternate" href="<%= localized_url(nil) %>" hreflang="x-default" />
 
-    <% I18n.available_locales.each do |l| %>
-      <link rel="alternate" hreflang="<%= l %>" href="<%= localized_url(l) %>" />
+    <% I18n.available_locales.each do |locale| %>
+      <link rel="alternate"
+            hreflang="<%= locale %>"
+            href="<%= localized_url(locale) %>" />
     <% end %>
 
     <!--


### PR DESCRIPTION
Añado `<link rel="canonical" .../>` al layout.

La idea es quitar el parámetro de búsqueda del canonical para que google ignore las URLs de búsqueda internas. Pensé en usar `robots.txt` o `no-index,no-follow`, pero creo que esto es mejor.