### PR TITLE
Cleanup messages table

### DIFF
--- a/db/migrate/20161001185104_remove_unused_columns_from_messages.rb
+++ b/db/migrate/20161001185104_remove_unused_columns_from_messages.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class RemoveUnusedColumnsFromMessages < ActiveRecord::Migration
+  def up
+    remove_column :messages, :draft, :boolean, default: false
+    remove_column :messages, :notification_code, :string, limit: 255
+    remove_column :messages, :attachment, :string, limit: 255
+    remove_column :messages, :global, :boolean, default: false
+    remove_column :messages, :expires, :datetime
+  end
+
+  def down
+    add_column :messages, :draft, :boolean, default: false
+    add_column :messages, :notification_code, :string, limit: 255
+    add_column :messages, :attachment, :string, limit: 255
+    add_column :messages, :global, :boolean, default: false
+    add_column :messages, :expires, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160930235635) do
+ActiveRecord::Schema.define(version: 20161001185104) do
 
   create_table "ads", force: :cascade do |t|
     t.string   "title",              limit: 100,               null: false
@@ -101,17 +101,12 @@ ActiveRecord::Schema.define(version: 20160930235635) do
   add_index "identities", ["user_id"], name: "index_identities_on_user_id", using: :btree
 
   create_table "messages", force: :cascade do |t|
-    t.text     "body",              limit: 16777215
-    t.string   "subject",           limit: 255,      default: ""
-    t.integer  "sender_id",         limit: 4
-    t.integer  "conversation_id",   limit: 4
-    t.boolean  "draft",                              default: false
-    t.datetime "updated_at",                                         null: false
-    t.datetime "created_at",                                         null: false
-    t.string   "notification_code", limit: 255
-    t.string   "attachment",        limit: 255
-    t.boolean  "global",                             default: false
-    t.datetime "expires"
+    t.text     "body",            limit: 16777215
+    t.string   "subject",         limit: 255,      default: ""
+    t.integer  "sender_id",       limit: 4
+    t.integer  "conversation_id", limit: 4
+    t.datetime "updated_at",                                    null: false
+    t.datetime "created_at",                                    null: false
   end
 
   add_index "messages", ["conversation_id"], name: "index_messages_on_conversation_id", using: :btree


### PR DESCRIPTION
There were a lot of legacy unused columns. Clean those up to reduce
complexity.