### PR TITLE
Fix some errors with old locales

### DIFF
--- a/app/controllers/concerns/multi_lingualizable.rb
+++ b/app/controllers/concerns/multi_lingualizable.rb
@@ -23,7 +23,14 @@ module MultiLingualizable
   end
 
   def cookie_locale
-    cookies.permanent[:locale].presence
+    locale = cookies.permanent[:locale]
+    # @note This validation is necessary because, although we validate the
+    # locale before saving the cookie, we've deprecated nl & eu locales so some
+    # cookies already set are no longer valid. Once we readd these locales we
+    # can remove this.
+    return unless valid_locale?(locale)
+
+    locale
   end
 
   def browser_locale
@@ -32,5 +39,11 @@ module MultiLingualizable
 
   def default_locale
     I18n.default_locale
+  end
+
+  def valid_locale?(locale)
+    return false unless locale.present?
+
+    I18n.available_locales.include?(locale.to_sym)
   end
 end

--- a/app/controllers/locales_controller.rb
+++ b/app/controllers/locales_controller.rb
@@ -36,12 +36,6 @@ class LocalesController < ApplicationController
     segments.join('/')
   end
 
-  def valid_locale?(locale)
-    return false unless locale.present?
-
-    I18n.available_locales.include?(locale.to_sym)
-  end
-
   def locale
     params[:locale]
   end

--- a/test/integration/locale_test.rb
+++ b/test/integration/locale_test.rb
@@ -28,6 +28,12 @@ class LocaleTest < ActionDispatch::IntegrationTest
     assert_equal :it, I18n.locale
   end
 
+  it 'ignores deprecated cookies in session' do
+    get root_path(locale: nil), {}, 'HTTP_COOKIE' => 'locale=eu;'
+
+    assert_equal I18n.default_locale, I18n.locale
+  end
+
   it 'assigns locale from browser if no locale in param or session' do
     get root_path(locale: nil), {}, 'HTTP_ACCEPT_LANGUAGE' => 'it'
 


### PR DESCRIPTION
If a user have the locale cookie set to a deprecated locale, app
crashes. Fix it.

Fixes https://err.nolotiro.org/apps/571de5807a440000b2000005/problems/57e786369efd720148000001.