### PR TITLE
Fix regression in messages order

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -69,7 +69,7 @@ class Conversation < ActiveRecord::Base
   end
 
   def messages_for(user)
-    messages.involving(user)
+    messages.involving(user).order(created_at: :asc)
   end
 
   def last_message

--- a/test/models/conversation_test.rb
+++ b/test/models/conversation_test.rb
@@ -120,4 +120,11 @@ class ConversationTest < ActiveSupport::TestCase
 
     assert_equal @recipient, @conversation.reload.recipient
   end
+
+  def test_messages_for_are_ordered_most_recent_last
+    @conversation.reply(sender: @user, recipient: @recipient, body: 'Hei!')
+    @conversation.save!
+
+    assert_equal 'Hei!', @conversation.messages_for(@user)[1].body
+  end
 end


### PR DESCRIPTION
After migration to PostgreSQL, the order was inverted.