### PR TITLE
Import Yahoo DB locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ public/assets/*
 # GeoLiteCity DB
 vendor/geolite/GeoLite2-City.mmdb
 
+# Geoplanet DB
+vendor/geoplanet
+
 # Gems when installed in deployment mode
 vendor/bundle/*
 

--- a/Gemfile
+++ b/Gemfile
@@ -94,3 +94,6 @@ gem 'json', '~> 1.8'
 
 gem 'bootstrap-sass', '~> 3.3'
 gem 'sass-rails', '~> 5.0'
+
+# Rake task utils
+gem 'rubyzip', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,6 +377,7 @@ GEM
       sexp_processor (~> 4.0)
     ruby_parser (3.8.2)
       sexp_processor (~> 4.1)
+    rubyzip (1.2.0)
     safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.6)
@@ -504,6 +505,7 @@ DEPENDENCIES
   redis-rails
   rest-client (~> 2.0)
   rubocop (= 0.45.0)
+  rubyzip
   sass-rails (~> 5.0)
   sdoc
   sidekiq

--- a/app/models/geoplanet/importer.rb
+++ b/app/models/geoplanet/importer.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'open-uri'
+require 'zip'
+require 'geoplanet/path_helper'
+require 'geoplanet/raw_importer'
+
+module Geoplanet
+  #
+  # Imports geographical Database information from Yahoo Geoplanet
+  #
+  class Importer
+    include PathHelper
+
+    def initialize
+      Dir.mkdir(local_base_path) unless File.exist?(local_base_path)
+
+      Rails.logger = Logger.new(STDOUT)
+    end
+
+    def import!
+      download!
+
+      RawImporter.new(
+        connection,
+        'places',
+        %w(woe_id iso name language place_type parent_id)
+      ).import!
+
+      RawImporter.new(
+        connection,
+        'admins',
+        %w(woe_id iso state county local_admin country continent)
+      ).import!
+
+      import_countries!
+      import_states!
+      import_towns!
+    end
+
+    private
+
+    def download!
+      Rails.logger.info 'Downloading DB from archive.org...'
+
+      return if File.exist?(local_compressed_path)
+
+      IO.copy_stream(open(compressed_url), local_compressed_path)
+    end
+
+    def import_countries!
+      Rails.logger.info 'Importing countries...'
+
+      connection.execute <<-SQL.squish
+        INSERT INTO countries(id, name, iso)
+        SELECT CAST(p.woe_id AS INTEGER), p.name, p.iso
+        FROM yahoo_places p
+        WHERE p.place_type in ('Country', 'Nationality')
+      SQL
+    end
+
+    def import_states!
+      Rails.logger.info 'Importing states...'
+
+      connection.execute <<-SQL.squish
+        INSERT INTO states(id, name, country_id)
+        SELECT CAST(p.woe_id AS INTEGER), p.name, CAST(a.country AS INTEGER)
+        FROM yahoo_places p INNER JOIN yahoo_admins a ON p.woe_id = a.woe_id
+        WHERE p.place_type = 'State'
+      SQL
+    end
+
+    def import_towns!
+      Rails.logger.info 'Importing towns...'
+
+      connection.execute <<-SQL.squish
+        INSERT INTO towns(id, name, state_id, country_id)
+        SELECT
+          CAST(p.woe_id AS INTEGER),
+          p.name,
+          CAST(NULLIF(a.state, '0') AS INTEGER),
+          CAST(a.country AS INTEGER)
+        FROM yahoo_places p INNER JOIN yahoo_admins a ON p.woe_id = a.woe_id
+        WHERE p.place_type = 'Town'
+      SQL
+    end
+
+    def connection
+      @connection ||= ActiveRecord::Base.connection
+    end
+  end
+end

--- a/app/models/geoplanet/path_helper.rb
+++ b/app/models/geoplanet/path_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Geoplanet
+  module PathHelper
+    def local_compressed_path
+      File.join(local_base_path, compressed_name)
+    end
+
+    def local_base_path
+      File.join(Rails.root, 'vendor', 'geoplanet')
+    end
+
+    def compressed_url
+      base_url + compressed_name
+    end
+
+    def compressed_name
+      'geoplanet_data_7.10.0.zip'
+    end
+
+    def base_url
+      'https://archive.org/download/geoplanet_data_7.10.0.zip/'
+    end
+  end
+end

--- a/app/models/geoplanet/raw_importer.rb
+++ b/app/models/geoplanet/raw_importer.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'zip'
+require 'geoplanet/path_helper'
+
+module Geoplanet
+  #
+  # Imports a resource from Geoplanet into our DB
+  #
+  class RawImporter
+    include PathHelper
+
+    attr_reader :resource, :columns, :connection
+
+    def initialize(connection, resource, columns)
+      @connection = connection
+      @resource = resource
+      @columns = columns
+    end
+
+    def import!
+      Rails.logger.info "Importing raw #{resource}..."
+
+      extract_file!
+      cleanup_orphan_entries!
+      create_temporary_table!
+      copy_file_to_temporary_table!
+    end
+
+    def extract_file!
+      Zip::File.open(local_compressed_path) do |zip_file|
+        zip_file.find_entry(tsv_name).extract(tsv_path) { true }
+      end
+    end
+
+    def cleanup_orphan_entries!
+      system('sed', '-i', "/^1321121\t/d", tsv_path)
+    end
+
+    def create_temporary_table!
+      connection.create_table :"yahoo_#{resource}", temporary: true do |t|
+        columns.each { |column| t.string column.to_sym }
+      end
+    end
+
+    def copy_file_to_temporary_table!
+      sql = <<-SQL.squish
+        COPY yahoo_#{resource}(#{columns.join(', ')}) FROM STDIN WITH CSV HEADER
+      SQL
+
+      raw_connection.copy_data(sql) do
+        File.open(tsv_path, 'r').each do |line|
+          raw_connection.put_copy_data(line.tr("\t", ','))
+        end
+      end
+
+      loop do
+        res = raw_connection.get_result
+        return unless res
+
+        error_message = res.error_message
+        next unless error_message
+
+        Rails.logger.warn error_message
+      end
+    end
+
+    delegate :raw_connection, to: :connection
+
+    def tsv_name
+      "geoplanet_#{resource}_7.10.0.tsv"
+    end
+
+    def tsv_path
+      File.join(local_base_path, tsv_name)
+    end
+  end
+end

--- a/db/migrate/20161117184138_create_geo_tables.rb
+++ b/db/migrate/20161117184138_create_geo_tables.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateGeoTables < ActiveRecord::Migration
+  def change
+    create_table :countries do |t|
+      t.string :iso, limit: 2, null: false
+      t.string :name, limit: 173, null: false
+    end
+
+    create_table :states do |t|
+      t.string :name, limit: 173, null: false
+      t.references :country, index: true, foreign_key: true, null: false
+    end
+
+    create_table :towns do |t|
+      t.string :name, limit: 173, null: false
+      t.references :state, index: true, foreign_key: true
+      t.references :country, index: true, foreign_key: true, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161019233040) do
+ActiveRecord::Schema.define(version: 20161117184138) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,6 +80,11 @@ ActiveRecord::Schema.define(version: 20161019233040) do
   add_index "conversations", ["originator_id"], name: "idx_16422_index_conversations_on_originator_id", using: :btree
   add_index "conversations", ["recipient_id"], name: "idx_16422_index_conversations_on_recipient_id", using: :btree
 
+  create_table "countries", force: :cascade do |t|
+    t.string "iso",  limit: 2,   null: false
+    t.string "name", limit: 173, null: false
+  end
+
   create_table "dismissals", id: :bigserial, force: :cascade do |t|
     t.integer "announcement_id", limit: 8
     t.integer "user_id",         limit: 8
@@ -131,6 +136,22 @@ ActiveRecord::Schema.define(version: 20161019233040) do
   add_index "receipts", ["notification_id"], name: "idx_16460_index_receipts_on_notification_id", using: :btree
   add_index "receipts", ["receiver_id"], name: "idx_16460_index_receipts_on_receiver_id", using: :btree
 
+  create_table "states", force: :cascade do |t|
+    t.string  "name",       limit: 173, null: false
+    t.integer "country_id",             null: false
+  end
+
+  add_index "states", ["country_id"], name: "index_states_on_country_id", using: :btree
+
+  create_table "towns", force: :cascade do |t|
+    t.string  "name",       limit: 173, null: false
+    t.integer "state_id"
+    t.integer "country_id",             null: false
+  end
+
+  add_index "towns", ["country_id"], name: "index_towns_on_country_id", using: :btree
+  add_index "towns", ["state_id"], name: "index_towns_on_state_id", using: :btree
+
   create_table "users", id: :bigserial, force: :cascade do |t|
     t.string   "username",               limit: 63,               null: false
     t.string   "legacy_password_hash",   limit: 255
@@ -174,4 +195,7 @@ ActiveRecord::Schema.define(version: 20161019233040) do
   add_foreign_key "identities", "users", on_update: :restrict, on_delete: :restrict
   add_foreign_key "messages", "conversations", name: "notifications_on_conversation_id", on_update: :restrict, on_delete: :restrict
   add_foreign_key "receipts", "messages", column: "notification_id", name: "receipts_on_notification_id", on_update: :restrict, on_delete: :restrict
+  add_foreign_key "states", "countries"
+  add_foreign_key "towns", "countries"
+  add_foreign_key "towns", "states"
 end

--- a/lib/tasks/geoplanet.rake
+++ b/lib/tasks/geoplanet.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :geoplanet do
+  desc 'Imports Geoplanet compressed db from archive.org'
+  task import: :environment do
+    require 'geoplanet/importer'
+
+    Geoplanet::Importer.new.import!
+  end
+end


### PR DESCRIPTION
This migrates Yahoo Geoplanet DB to our internal DB, so we can control the content and don't need to rely on an external API. Yahoo's API has proven to be very unstable, so we should get rid of it. This results in faster and simpler code.

There's one downside. We no longer have translations of geographical places since Geoplanet's schema and translation rules were too complicated to bother. I think this is good enough for now since we only have Spanish speaking traffic in Spain. But I'm open for suggestions.

I'll make a data migration plan in the following days. This should be deployed in 2 or 3 stages.
