### PR TITLE
Don't show full exception message on 401 errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,12 +12,8 @@ class ApplicationController < ActionController::Base
 
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-  rescue_from Pundit::NotAuthorizedError do |exception|
-    if user_signed_in?
-      redirect_to root_url, alert: t('nlt.permission_denied')
-    else
-      redirect_to new_user_session_url, alert: exception.message
-    end
+  rescue_from Pundit::NotAuthorizedError do |_exception|
+    redirect_to request.referer || root_path, alert: t('nlt.permission_denied')
   end
 
   def access_denied(exception)

--- a/test/controllers/ads_controller_test.rb
+++ b/test/controllers/ads_controller_test.rb
@@ -143,7 +143,7 @@ class AdsControllerTest < ActionController::TestCase
 
   test 'should not destroy ad as anonymous' do
     assert_difference('Ad.count', 0) { delete :destroy, id: @ad }
-    assert_redirected_to new_user_session_url
+    assert_redirected_to root_path
   end
 
   test 'should not destroy non-owned ads as normal user' do


### PR DESCRIPTION
The simpler message works better. Also, redirect to the referer if
there's any.