### PR TITLE
Dealing with empty content

### DIFF
--- a/app/assets/stylesheets/_common.sass.erb
+++ b/app/assets/stylesheets/_common.sass.erb
@@ -233,12 +233,10 @@ form.searchbox
     float: right
 
 .no_results
-  display: block
-  float: left
-  padding-left: 18px
-  padding-right: 18px
-  padding-top: 0
   margin-top: 10px
+
+  h2
+    margin-bottom: 1.6em
 
 .filter_status
   padding: 10px 18px 12px 0

--- a/app/views/ads/_no_results.html.erb
+++ b/app/views/ads/_no_results.html.erb
@@ -2,18 +2,18 @@
   <h2><%= t('nlt.no_results.title') %></h2>
   <h3><%= t('nlt.no_results.subtitle') %></h3>
 
-  <ul>
-    <li>
+  <ul class="list-group">
+    <li class="list-group-item">
       <%= t('nlt.no_results.first_to_publish_html',
             publish: link_to(t('nlt.no_results.publish_ad'), new_ad_path)) %>
     </li>
 
-    <li>
+    <li class="list-group-item">
       <%= t('nlt.no_results.switch_to_bigger_city') %>
     </li>
 
     <% if location_suggest %>
-      <li>
+      <li class="list-group-item">
         <% link = link_to_change_location(location_suggest.fullname) %>
         <%= t('nlt.no_results.switch_to_guessed_city_html',
               change_location: link) %>

--- a/app/views/ads/_no_results.html.erb
+++ b/app/views/ads/_no_results.html.erb
@@ -2,25 +2,26 @@
   <h2><%= t('nlt.no_results.title') %></h2>
   <h3><%= t('nlt.no_results.subtitle') %></h3>
 
-  <p>
-    <%= t('nlt.no_results.first_to_publish_html',
-          publish: link_to(t('nlt.no_results.publish_ad'), new_ad_path)) %>
-  </p>
+  <ul>
+    <li>
+      <%= t('nlt.no_results.first_to_publish_html',
+            publish: link_to(t('nlt.no_results.publish_ad'), new_ad_path)) %>
+    </li>
 
-  <p>
-    <%= t('nlt.no_results.switch_to_bigger_city') %>
-  </p>
+    <li>
+      <%= t('nlt.no_results.switch_to_bigger_city') %>
+    </li>
 
-  <% if location_suggest %>
-    <p>
-      <% link = link_to_change_location(location_suggest.fullname) %>
-      <%= t('nlt.no_results.switch_to_guessed_city_html',
-            change_location: link) %>
-    </p>
-  <% end %>
+    <% if location_suggest %>
+      <li>
+        <% link = link_to_change_location(location_suggest.fullname) %>
+        <%= t('nlt.no_results.switch_to_guessed_city_html',
+              change_location: link) %>
+      </li>
+    <% end %>
+  </ul>
 
   <h5>
     <i><%= t('nlt.no_results.phrase') %></i>
   </h5>
-
 </div>

--- a/app/views/ads/_no_results.html.erb
+++ b/app/views/ads/_no_results.html.erb
@@ -1,6 +1,7 @@
 <div class="no_results">
   <h2><%= t('nlt.no_results.title') %></h2>
-  <h3><%= t('nlt.no_results.subtitle') %></h3>
+
+  <p><%= t('nlt.no_results.subtitle') %></p>
 
   <ul class="list-group">
     <li class="list-group-item">
@@ -22,7 +23,7 @@
     <% end %>
   </ul>
 
-  <h5>
+  <p>
     <i><%= t('nlt.no_results.phrase') %></i>
-  </h5>
+  </p>
 </div>

--- a/app/views/ads/_no_results.html.erb
+++ b/app/views/ads/_no_results.html.erb
@@ -9,7 +9,8 @@
     </li>
 
     <li class="list-group-item">
-      <%= t('nlt.no_results.switch_to_bigger_city') %>
+      <% link = link_to(t('nlt.no_results.choose_bigger'), location_ask_path) %>
+      <%= t('nlt.no_results.switch_to_bigger_city_html', choose_bigger: link) %>
     </li>
 
     <% if location_suggest %>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,0 +1,58 @@
+<title><%= yield(:meta_title) %> - nolotiro.org</title>
+<meta charset="utf-8" />
+<%= favicon_link_tag 'favicon.ico' %>
+<%= stylesheet_link_tag "application", media: "all" %>
+
+<%= csrf_meta_tags %>
+
+<%= meta_description %>
+
+<% if content_for?(:meta_extra) %>
+  <%= yield(:meta_extra) %>
+<% end %>
+
+<meta name='viewport' content='width=device-width, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no' />
+
+<link rel="canonical" href="<%= canonical_url %>" />
+
+<link rel="alternate" href="<%= localized_url(nil) %>" hreflang="x-default" />
+
+<% I18n.available_locales.each do |locale| %>
+  <link rel="alternate"
+        hreflang="<%= locale.to_s %>"
+        href="<%= localized_url(locale) %>" />
+<% end %>
+
+<!--
+
+       Esta web está hecha por la asociación aLabs (http://alabs.es).
+       Puedes ver el código en https://github.com/alabs/nolotiro.org/
+
+                   @@@@              @@@@                 @+`
+                   @@@@              @@@@               @@@@@`
+           `..`    @@@@      ,;;,    @@@@ ,;,    `:;:`   ,@@`
+         `::::::.  @@@@    .@@@@@@:  @@@@@@@@@  @@@@@@@  @#@@
+         ::::::::  @@@@    @@@@@@@@  @@@@@@@@@`:@@@@@@@#
+        .:::`,:::. @@@@   :@@@.;@@@; @@@@ @@@@.@@@@ @@@@
+        ,::: ,:::: @@@@   '@@@.,@@@+ @@@@ @@@@.@@@@ @@@@
+        :::: ::::; @@@@   '@@@.'@@@# @@@@ @@@@.+@@@@
+           .:::::; @@@@      :@@@@@# @@@@ @@@@. @@@@@#
+         ,:::::::; @@@@    +@@@@@@@# @@@@ @@@@. .@@@@@@`
+        `:::;,:::; @@@@   .@@@@,@@@# @@@@ @@@@.   #@@@@@
+        ,:::`,:::; @@@@   '@@@,,@@@# @@@@ @@@@.#@@@ @@@@
+        :::: ,:::; @@@@   '@@@.,@@@# @@@@ @@@@.+@@@ #@@@
+        ,::: ::::; @@@@@@@'@@@.;@@@# @@@@ @@@@`:@@@ @@@@
+        .::::::::; @@@@@@@.@@@@@@@@# @@@@@@@@@  @@@@@@@@
+         ::::::::; @@@@@@@ @@@@'@@@# @@@@#@@@+  .@@@@@@`
+          .:                `:`            :`     `::`
+
+-->
+
+<script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+
+<script>
+  (adsbygoogle = window.adsbygoogle || []).push({
+    google_ad_client: "ca-pub-5360961269901609",
+    enable_page_level_ads: true
+  });
+</script>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -7,6 +7,10 @@
 
 <%= meta_description %>
 
+<% if content_for?(:meta_robots) %>
+  <%= yield(:meta_robots) %>
+<% end %>
+
 <% if content_for?(:meta_extra) %>
   <%= yield(:meta_extra) %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,64 +1,7 @@
 <!DOCTYPE html>
 <html lang="<%= locale %>">
   <head>
-    <title><%= yield(:meta_title) %> - nolotiro.org</title>
-    <meta charset="utf-8" />
-    <%= favicon_link_tag 'favicon.ico' %>
-    <%= stylesheet_link_tag "application", media: "all" %>
-
-    <%= csrf_meta_tags %>
-
-    <%= meta_description %>
-
-    <% if content_for?(:meta_extra) %>
-      <%= yield(:meta_extra) %>
-    <% end %>
-
-    <meta name='viewport' content='width=device-width, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no' />
-
-    <link rel="canonical" href="<%= canonical_url %>" />
-
-    <link rel="alternate" href="<%= localized_url(nil) %>" hreflang="x-default" />
-
-    <% I18n.available_locales.each do |locale| %>
-      <link rel="alternate"
-            hreflang="<%= locale.to_s %>"
-            href="<%= localized_url(locale) %>" />
-    <% end %>
-
-    <!--
-
-           Esta web está hecha por la asociación aLabs (http://alabs.es).
-           Puedes ver el código en https://github.com/alabs/nolotiro.org/
-
-                       @@@@              @@@@                 @+`
-                       @@@@              @@@@               @@@@@`
-               `..`    @@@@      ,;;,    @@@@ ,;,    `:;:`   ,@@`
-             `::::::.  @@@@    .@@@@@@:  @@@@@@@@@  @@@@@@@  @#@@
-             ::::::::  @@@@    @@@@@@@@  @@@@@@@@@`:@@@@@@@#
-            .:::`,:::. @@@@   :@@@.;@@@; @@@@ @@@@.@@@@ @@@@
-            ,::: ,:::: @@@@   '@@@.,@@@+ @@@@ @@@@.@@@@ @@@@
-            :::: ::::; @@@@   '@@@.'@@@# @@@@ @@@@.+@@@@
-               .:::::; @@@@      :@@@@@# @@@@ @@@@. @@@@@#
-             ,:::::::; @@@@    +@@@@@@@# @@@@ @@@@. .@@@@@@`
-            `:::;,:::; @@@@   .@@@@,@@@# @@@@ @@@@.   #@@@@@
-            ,:::`,:::; @@@@   '@@@,,@@@# @@@@ @@@@.#@@@ @@@@
-            :::: ,:::; @@@@   '@@@.,@@@# @@@@ @@@@.+@@@ #@@@
-            ,::: ::::; @@@@@@@'@@@.;@@@# @@@@ @@@@`:@@@ @@@@
-            .::::::::; @@@@@@@.@@@@@@@@# @@@@@@@@@  @@@@@@@@
-             ::::::::; @@@@@@@ @@@@'@@@# @@@@#@@@+  .@@@@@@`
-              .:                `:`            :`     `::`
-
-    -->
-
-    <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-
-    <script>
-      (adsbygoogle = window.adsbygoogle || []).push({
-        google_ad_client: "ca-pub-5360961269901609",
-        enable_page_level_ads: true
-      });
-    </script>
+    <%= render 'layouts/head' %>
   </head>
 
   <body>

--- a/app/views/woeid/show.html.erb
+++ b/app/views/woeid/show.html.erb
@@ -82,12 +82,10 @@
     <%= will_paginate @ads, params: params.merge(id: current_woeid),
                             inner_window: 2,
                             outer_window: -1 %>
+  <% elsif @q %>
+    <%= render "ads/no_results_search" %>
   <% else %>
-    <% if @q %>
-      <%= render "ads/no_results_search" %>
-    <% else %>
-      <%= render "ads/no_results" %>
-    <% end %>
+    <%= render "ads/no_results" %>
   <% end %>
 
   <% if current_woeid %>

--- a/app/views/woeid/show.html.erb
+++ b/app/views/woeid/show.html.erb
@@ -83,6 +83,16 @@
                             inner_window: 2,
                             outer_window: -1 %>
   <% elsif @q %>
+    <%
+      # @todo In the future we might want to enhance this page with interesting
+      # content for the user, such as related searches or hits in locations a
+      # little bit further away. But for now this is a dummy page where google
+      # is giving soft 404 errors. So just remove indexing for now
+    %>
+    <% content_for :meta_robots do %>
+      <meta name="robots" content="noindex,nofollow">
+    <% end %>
+
     <%= render "ads/no_results_search" %>
   <% else %>
     <%= render "ads/no_results" %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -284,7 +284,7 @@ ca:
       publish_ad: publicar un anunci en aquesta ciutat
       subtitle: Pots provar alguna d'aquestes coses
       switch_to_bigger_city_html: "%{choose_bigger} que estigui a prop de la teva ubicació."
-      switch_to_guessed_city_html: 'El nostre sistema de suggeriment d''ubicació (basat en la teva IP) diu que aquestes prop de: <br> %{change_location}'
+      switch_to_guessed_city_html: 'Comprova que has triat la teva ciutat correctament. El nostre sistema de suggeriment d''ubicació (basat en la teva IP) diu que aquestes prop de: <br> %{change_location}'
       title: No hi ha anuncis per a aquesta ubicació.
     password: Contrasenya
     permission_denied: No tens permisos per a realitzar aquesta acció.

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -277,13 +277,13 @@ ca:
     new_user: nou usuari
     no_location_specified: 
     no_results:
-      first_to_publish_html: 1. Sigues el primer a %{publish}.
+      first_to_publish_html: Sigues el primer a %{publish}.
       on_user: No hi ha anuncis d'aquest tipus publicats per aquest usuari.
       phrase: '"Un viatge de mil quilòmetres comença amb un simple pas", Lao Tse.'
       publish_ad: publicar un anunci en aquesta ciutat
       subtitle: Pots provar alguna d'aquestes coses
-      switch_to_bigger_city: 2. Prova a canviar la ciutat per una més gran que estigui a prop de la teva ubicació.
-      switch_to_guessed_city_html: '3. El nostre sistema de suggeriment d''ubicació (basat en la teva IP) diu que aquestes prop de: <br> %{change_location}'
+      switch_to_bigger_city: Prova a canviar la ciutat per una més gran que estigui a prop de la teva ubicació.
+      switch_to_guessed_city_html: 'El nostre sistema de suggeriment d''ubicació (basat en la teva IP) diu que aquestes prop de: <br> %{change_location}'
       title: No hi ha anuncis per a aquesta ubicació.
     password: Contrasenya
     permission_denied: No tens permisos per a realitzar aquesta acció.

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -277,12 +277,13 @@ ca:
     new_user: nou usuari
     no_location_specified: 
     no_results:
+      choose_bigger: Tria una ciutat més gran
       first_to_publish_html: Sigues el primer a %{publish}.
       on_user: No hi ha anuncis d'aquest tipus publicats per aquest usuari.
       phrase: '"Un viatge de mil quilòmetres comença amb un simple pas", Lao Tse.'
       publish_ad: publicar un anunci en aquesta ciutat
       subtitle: Pots provar alguna d'aquestes coses
-      switch_to_bigger_city: Prova a canviar la ciutat per una més gran que estigui a prop de la teva ubicació.
+      switch_to_bigger_city_html: "%{choose_bigger} que estigui a prop de la teva ubicació."
       switch_to_guessed_city_html: 'El nostre sistema de suggeriment d''ubicació (basat en la teva IP) diu que aquestes prop de: <br> %{change_location}'
       title: No hi ha anuncis per a aquesta ubicació.
     password: Contrasenya

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -284,7 +284,7 @@ ca:
       publish_ad: publicar un anunci en aquesta ciutat
       subtitle: Pots provar alguna d'aquestes coses
       switch_to_bigger_city_html: "%{choose_bigger} que estigui a prop de la teva ubicació."
-      switch_to_guessed_city_html: 'Comprova que has triat la teva ciutat correctament. El nostre sistema de suggeriment d''ubicació (basat en la teva IP) diu que aquestes prop de: <br> %{change_location}'
+      switch_to_guessed_city_html: 'Comprova que has triat la teva ciutat correctament. El nostre sistema de suggeriment d''ubicació (basat en la teva IP) diu que aquestes prop de %{change_location}'
       title: No hi ha anuncis per a aquesta ubicació.
     password: Contrasenya
     permission_denied: No tens permisos per a realitzar aquesta acció.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -277,12 +277,13 @@ de:
     new_user: 
     no_location_specified: 
     no_results:
+      choose_bigger: 
       first_to_publish_html: 
       on_user: 
       phrase: 
       publish_ad: 
       subtitle: 
-      switch_to_bigger_city: 
+      switch_to_bigger_city_html: 
       switch_to_guessed_city_html: 
       title: 
     password: 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -277,13 +277,13 @@ en:
     new_user: sign up
     no_location_specified: You must search in a specific city
     no_results:
-      first_to_publish_html: 1. Be the first to %{publish}.
+      first_to_publish_html: Be the first to %{publish}.
       on_user: There are no ads of this kind published by this user.
       phrase: '"The journey of a thousand miles begins with one step", Lao Tse.'
       publish_ad: post an ad in this city
       subtitle: You can try some of this stuff
-      switch_to_bigger_city: 2. Try a bigger city close to your location.
-      switch_to_guessed_city_html: '3. Our IP based city suggestion system tells us you are close to: <br> %{change_location}'
+      switch_to_bigger_city: Try a bigger city close to your location.
+      switch_to_guessed_city_html: 'Our IP based city suggestion system tells us you are close to: <br> %{change_location}'
       title: There are no results in this location
     password: Password
     permission_denied: You don't have permissions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -284,7 +284,7 @@ en:
       publish_ad: post an ad in this city
       subtitle: You can try some of this stuff
       switch_to_bigger_city_html: "%{choose_bigger} close to your location."
-      switch_to_guessed_city_html: 'Double check the city you have chosen. Our IP based city suggestion system tells us you are close to: <br> %{change_location}'
+      switch_to_guessed_city_html: 'Double check the city you have chosen. Our IP based city suggestion system tells us you are close to %{change_location}'
       title: There are no results in this location
     password: Password
     permission_denied: You don't have permissions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -277,12 +277,13 @@ en:
     new_user: sign up
     no_location_specified: You must search in a specific city
     no_results:
+      choose_bigger: Choose a bigger city
       first_to_publish_html: Be the first to %{publish}.
       on_user: There are no ads of this kind published by this user.
       phrase: '"The journey of a thousand miles begins with one step", Lao Tse.'
       publish_ad: post an ad in this city
       subtitle: You can try some of this stuff
-      switch_to_bigger_city: Try a bigger city close to your location.
+      switch_to_bigger_city_html: "%{choose_bigger} close to your location."
       switch_to_guessed_city_html: 'Our IP based city suggestion system tells us you are close to: <br> %{change_location}'
       title: There are no results in this location
     password: Password

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -284,7 +284,7 @@ en:
       publish_ad: post an ad in this city
       subtitle: You can try some of this stuff
       switch_to_bigger_city_html: "%{choose_bigger} close to your location."
-      switch_to_guessed_city_html: 'Our IP based city suggestion system tells us you are close to: <br> %{change_location}'
+      switch_to_guessed_city_html: 'Double check the city you have chosen. Our IP based city suggestion system tells us you are close to: <br> %{change_location}'
       title: There are no results in this location
     password: Password
     permission_denied: You don't have permissions

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -284,7 +284,7 @@ es:
       publish_ad: publicar un anuncio en esta ciudad
       subtitle: Puedes probar alguna de estas cosas
       switch_to_bigger_city_html: "%{choose_bigger} que esté cerca de tu ubicación."
-      switch_to_guessed_city_html: 'Comprueba que has elegido tu ciudad correctamente. Nuestro sistema de sugerencia de ubicación (basado en tu IP) dice que estás cerca de: <br> %{change_location}'
+      switch_to_guessed_city_html: 'Comprueba que has elegido tu ciudad correctamente. Nuestro sistema de sugerencia de ubicación (basado en tu IP) dice que estás cerca de %{change_location}'
       title: No hay anuncios para esta ubicación.
     password: Contraseña
     permission_denied: No tienes permisos para realizar esta acción.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -277,12 +277,13 @@ es:
     new_user: nuevo usuario
     no_location_specified: Debes buscar en una ciudad específica
     no_results:
+      choose_bigger: Elige una ciudad más grande
       first_to_publish_html: Sé el primero en %{publish}.
       on_user: No hay anuncios de este tipo publicados por este usuario.
       phrase: '"Un viaje de mil kilómetros comienza con un simple paso", Lao Tse.'
       publish_ad: publicar un anuncio en esta ciudad
       subtitle: Puedes probar alguna de estas cosas
-      switch_to_bigger_city: Prueba a cambiar la ciudad por una más grande que esté cerca de tu ubicación.
+      switch_to_bigger_city_html: "%{choose_bigger} que esté cerca de tu ubicación."
       switch_to_guessed_city_html: 'Nuestro sistema de sugerencia de ubicación (basado en tu IP) dice que estás cerca de: <br> %{change_location}'
       title: No hay anuncios para esta ubicación.
     password: Contraseña

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -284,7 +284,7 @@ es:
       publish_ad: publicar un anuncio en esta ciudad
       subtitle: Puedes probar alguna de estas cosas
       switch_to_bigger_city_html: "%{choose_bigger} que esté cerca de tu ubicación."
-      switch_to_guessed_city_html: 'Nuestro sistema de sugerencia de ubicación (basado en tu IP) dice que estás cerca de: <br> %{change_location}'
+      switch_to_guessed_city_html: 'Comprueba que has elegido tu ciudad correctamente. Nuestro sistema de sugerencia de ubicación (basado en tu IP) dice que estás cerca de: <br> %{change_location}'
       title: No hay anuncios para esta ubicación.
     password: Contraseña
     permission_denied: No tienes permisos para realizar esta acción.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -277,13 +277,13 @@ es:
     new_user: nuevo usuario
     no_location_specified: Debes buscar en una ciudad específica
     no_results:
-      first_to_publish_html: 1. Sé el primero en %{publish}.
+      first_to_publish_html: Sé el primero en %{publish}.
       on_user: No hay anuncios de este tipo publicados por este usuario.
       phrase: '"Un viaje de mil kilómetros comienza con un simple paso", Lao Tse.'
       publish_ad: publicar un anuncio en esta ciudad
       subtitle: Puedes probar alguna de estas cosas
-      switch_to_bigger_city: 2. Prueba a cambiar la ciudad por una más grande que esté cerca de tu ubicación.
-      switch_to_guessed_city_html: '3. Nuestro sistema de sugerencia de ubicación (basado en tu IP) dice que estás cerca de: <br> %{change_location}'
+      switch_to_bigger_city: Prueba a cambiar la ciudad por una más grande que esté cerca de tu ubicación.
+      switch_to_guessed_city_html: 'Nuestro sistema de sugerencia de ubicación (basado en tu IP) dice que estás cerca de: <br> %{change_location}'
       title: No hay anuncios para esta ubicación.
     password: Contraseña
     permission_denied: No tienes permisos para realizar esta acción.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -284,7 +284,7 @@ fr:
       publish_ad: publier une annonce dans cette ville
       subtitle: Vous pouvez essayer une de ces choses
       switch_to_bigger_city_html: "%{choose_bigger} à côté de votre emplacement."
-      switch_to_guessed_city_html: 'Vérifiez que vous avez choisi correctement votre ville. Notre emplacement du système de suggestion (basé sur votre IP) indique que vous êtes près de: <br> %{change_location}'
+      switch_to_guessed_city_html: 'Vérifiez que vous avez choisi correctement votre ville. Notre emplacement du système de suggestion (basé sur votre IP) indique que vous êtes près de %{change_location}'
       title: Aucune annonce pour ce lieu.
     password: Mot de passe
     permission_denied: Vous n'êtes pas autorisé à effectuer cette action.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -277,13 +277,13 @@ fr:
     new_user: nouvel utilisateur
     no_location_specified: 
     no_results:
-      first_to_publish_html: 1. Soyez le premier à publier %{publish}.
+      first_to_publish_html: Soyez le premier à publier %{publish}.
       on_user: Aucune de ces annonces publiées par cet utilisateur.
       phrase: «Un voyage de mille kilomètres commence par un premier pas", Lao Tse.
       publish_ad: publier une annonce dans cette ville
       subtitle: Vous pouvez essayer une de ces choses
-      switch_to_bigger_city: 2. Essayez de changer la ville pour un plus grand que vous êtes à proximité de votre emplacement.
-      switch_to_guessed_city_html: '3. Notre emplacement du système de suggestion (basé sur votre IP) indique que vous êtes près de: <br> %{change_location}'
+      switch_to_bigger_city: Essayez de changer la ville pour un plus grand que vous êtes à proximité de votre emplacement.
+      switch_to_guessed_city_html: 'Notre emplacement du système de suggestion (basé sur votre IP) indique que vous êtes près de: <br> %{change_location}'
       title: Aucune annonce pour ce lieu.
     password: Mot de passe
     permission_denied: Vous n'êtes pas autorisé à effectuer cette action.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -284,7 +284,7 @@ fr:
       publish_ad: publier une annonce dans cette ville
       subtitle: Vous pouvez essayer une de ces choses
       switch_to_bigger_city_html: "%{choose_bigger} à côté de votre emplacement."
-      switch_to_guessed_city_html: 'Notre emplacement du système de suggestion (basé sur votre IP) indique que vous êtes près de: <br> %{change_location}'
+      switch_to_guessed_city_html: 'Vérifiez que vous avez choisi correctement votre ville. Notre emplacement du système de suggestion (basé sur votre IP) indique que vous êtes près de: <br> %{change_location}'
       title: Aucune annonce pour ce lieu.
     password: Mot de passe
     permission_denied: Vous n'êtes pas autorisé à effectuer cette action.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -277,12 +277,13 @@ fr:
     new_user: nouvel utilisateur
     no_location_specified: 
     no_results:
+      choose_bigger: Choisisez une ville plus grand
       first_to_publish_html: Soyez le premier à publier %{publish}.
       on_user: Aucune de ces annonces publiées par cet utilisateur.
       phrase: «Un voyage de mille kilomètres commence par un premier pas", Lao Tse.
       publish_ad: publier une annonce dans cette ville
       subtitle: Vous pouvez essayer une de ces choses
-      switch_to_bigger_city: Essayez de changer la ville pour un plus grand que vous êtes à proximité de votre emplacement.
+      switch_to_bigger_city_html: "%{choose_bigger} à côté de votre emplacement."
       switch_to_guessed_city_html: 'Notre emplacement du système de suggestion (basé sur votre IP) indique que vous êtes près de: <br> %{change_location}'
       title: Aucune annonce pour ce lieu.
     password: Mot de passe

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -285,12 +285,13 @@ gl:
     new_user: 
     no_location_specified: 
     no_results:
+      choose_bigger: 
       first_to_publish_html: 
       on_user: 
       phrase: 
       publish_ad: 
       subtitle: 
-      switch_to_bigger_city: 
+      switch_to_bigger_city_html: 
       switch_to_guessed_city_html: 
       title: 
     password: Contrasinal

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -288,7 +288,7 @@ it:
       publish_ad: pubblicare un annuncio in questa città
       subtitle: Si può provare una qualsiasi di queste cose
       switch_to_bigger_city_html: "%{choose_bigger} vicino da te."
-      switch_to_guessed_city_html: 'Il nostro sistema di suggerimento (in base alla tua IP) dice che ti trovi vicino a: <br> %{change_location}'
+      switch_to_guessed_city_html: 'Verifica di aver scelto correttamente la tua cità. Il nostro sistema di suggerimento (in base alla tua IP) dice che ti trovi vicino a: <br> %{change_location}'
       title: Nessun annuncio per questa posizione.
     password: password
     permission_denied: Non si dispone dell'autorizzazione per eseguire questa azione.

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -281,12 +281,13 @@ it:
     new_user: nuovo utente
     no_location_specified: Devi cercare in una città specifica
     no_results:
+      choose_bigger: Sceglie una città più grande
       first_to_publish_html: Puoi essere il primo a %{publish}.
       on_user: Nessuna di tali annunci da questo utente.
       phrase: '"Un viaggio di mille chilometri inizia con un singolo passo", Lao Tse.'
       publish_ad: pubblicare un annuncio in questa città
       subtitle: Si può provare una qualsiasi di queste cose
-      switch_to_bigger_city: Prova a cambiare la città per una più grande vicino da te.
+      switch_to_bigger_city_html: "%{choose_bigger} vicino da te."
       switch_to_guessed_city_html: 'Il nostro sistema di suggerimento (in base alla tua IP) dice che ti trovi vicino a: <br> %{change_location}'
       title: Nessun annuncio per questa posizione.
     password: password

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -288,7 +288,7 @@ it:
       publish_ad: pubblicare un annuncio in questa città
       subtitle: Si può provare una qualsiasi di queste cose
       switch_to_bigger_city_html: "%{choose_bigger} vicino da te."
-      switch_to_guessed_city_html: 'Verifica di aver scelto correttamente la tua cità. Il nostro sistema di suggerimento (in base alla tua IP) dice che ti trovi vicino a: <br> %{change_location}'
+      switch_to_guessed_city_html: 'Verifica di aver scelto correttamente la tua cità. Il nostro sistema di suggerimento (in base alla tua IP) dice che ti trovi vicino a %{change_location}'
       title: Nessun annuncio per questa posizione.
     password: password
     permission_denied: Non si dispone dell'autorizzazione per eseguire questa azione.

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -281,13 +281,13 @@ it:
     new_user: nuovo utente
     no_location_specified: Devi cercare in una città specifica
     no_results:
-      first_to_publish_html: 1. Puoi essere il primo a %{publish}.
+      first_to_publish_html: Puoi essere il primo a %{publish}.
       on_user: Nessuna di tali annunci da questo utente.
       phrase: '"Un viaggio di mille chilometri inizia con un singolo passo", Lao Tse.'
       publish_ad: pubblicare un annuncio in questa città
       subtitle: Si può provare una qualsiasi di queste cose
-      switch_to_bigger_city: 2. Prova a cambiare la città per una più grande vicino da te.
-      switch_to_guessed_city_html: '3. Il nostro sistema di suggerimento (in base alla tua IP) dice che ti trovi vicino a: <br> %{change_location}'
+      switch_to_bigger_city: Prova a cambiare la città per una più grande vicino da te.
+      switch_to_guessed_city_html: 'Il nostro sistema di suggerimento (in base alla tua IP) dice che ti trovi vicino a: <br> %{change_location}'
       title: Nessun annuncio per questa posizione.
     password: password
     permission_denied: Non si dispone dell'autorizzazione per eseguire questa azione.

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -284,7 +284,7 @@ pt:
       publish_ad: publicar um anúncio em esta cidade
       subtitle: Você pode tentar com alguma de estas coisas
       switch_to_bigger_city_html: "%{choose_bigger} que esteja perto da sua localização."
-      switch_to_guessed_city_html: Confira se vôce escolheu la sua cidade corretamente. Nosso sistema de sugestões de localização (baseado na sua IP) disse que voçê está perto de <br> %{change_location}
+      switch_to_guessed_city_html: Confira se vôce escolheu la sua cidade corretamente. Nosso sistema de sugestões de localização (baseado na sua IP) disse que voçê está perto de %{change_location}
       title: Não existem anúncios para esta localização.
     password: Senha
     permission_denied: Você não tem permissão para executar esta ação

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -277,12 +277,13 @@ pt:
     new_user: novo usuário
     no_location_specified: 
     no_results:
+      choose_bigger: Escolha uma ciudade mais grande
       first_to_publish_html: Seja o primeiro em %{publish}.
       on_user: Não existem anúncios de este tipo publicados por este usuário.
       phrase: '"Uma viagem de mil quilômetros começa com um simples passo", Lao Tse'
       publish_ad: publicar um anúncio em esta cidade
       subtitle: Você pode tentar com alguma de estas coisas
-      switch_to_bigger_city: Tenta trocar a cidade por uma outra mayor que esteja perto da sua localização.
+      switch_to_bigger_city_html: "%{choose_bigger} que esteja perto da sua localização."
       switch_to_guessed_city_html: Nosso sistema de sugestões de localização (baseado na sua IP) disse que voçê está perto de <br> %{change_location}
       title: Não existem anúncios para esta localização.
     password: Senha

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -284,7 +284,7 @@ pt:
       publish_ad: publicar um anúncio em esta cidade
       subtitle: Você pode tentar com alguma de estas coisas
       switch_to_bigger_city_html: "%{choose_bigger} que esteja perto da sua localização."
-      switch_to_guessed_city_html: Nosso sistema de sugestões de localização (baseado na sua IP) disse que voçê está perto de <br> %{change_location}
+      switch_to_guessed_city_html: Confira se vôce escolheu la sua cidade corretamente. Nosso sistema de sugestões de localização (baseado na sua IP) disse que voçê está perto de <br> %{change_location}
       title: Não existem anúncios para esta localização.
     password: Senha
     permission_denied: Você não tem permissão para executar esta ação

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -277,13 +277,13 @@ pt:
     new_user: novo usuário
     no_location_specified: 
     no_results:
-      first_to_publish_html: 1. Seja o primeiro em %{publish}.
+      first_to_publish_html: Seja o primeiro em %{publish}.
       on_user: Não existem anúncios de este tipo publicados por este usuário.
       phrase: '"Uma viagem de mil quilômetros começa com um simples passo", Lao Tse'
       publish_ad: publicar um anúncio em esta cidade
       subtitle: Você pode tentar com alguma de estas coisas
-      switch_to_bigger_city: 2. Tenta trocar a cidade por uma outra mayor que esteja perto da sua localização.
-      switch_to_guessed_city_html: 3. Nosso sistema de sugestões de localização (baseado na sua IP) disse que voçê está perto de <br> %{change_location}
+      switch_to_bigger_city: Tenta trocar a cidade por uma outra mayor que esteja perto da sua localização.
+      switch_to_guessed_city_html: Nosso sistema de sugestões de localização (baseado na sua IP) disse que voçê está perto de <br> %{change_location}
       title: Não existem anúncios para esta localização.
     password: Senha
     permission_denied: Você não tem permissão para executar esta ação


### PR DESCRIPTION
There's currently 2 empty pages in the web:

* __The empty city page__: This page contains suggestions and some meaningful links. I took the chance to improve the content a bit.

* __The empty search page__: This is currently very dummy and empty and google tags it as a "soft 404". The prevent that, and until we can enhance it with related searches or hits in locations a bit further away "ala wallapop", I marked these pages as "noindex,nofollow".

Fixes #454.