### PR TITLE
Fix account removal

### DIFF
--- a/app/admin/helpers/stats_sidebar.rb
+++ b/app/admin/helpers/stats_sidebar.rb
@@ -2,7 +2,7 @@
 
 module StatsSidebar
   def self.included(dsl)
-    dsl.sidebar 'Estadísticas' do
+    dsl.sidebar 'Estadísticas', only: :index do
       scope = dsl.controller.resource_class
       scope = scope.public_send(current_scope.scope_method) if current_scope
 

--- a/app/assets/stylesheets/_common.sass.erb
+++ b/app/assets/stylesheets/_common.sass.erb
@@ -529,7 +529,10 @@ dl, dd
   width: 100%
   border-bottom: 1px solid $gray-separator
 
-.ad_content
+// This should be named `ad_content` but AdBlock doesn't like that.
+// @todo: Rename `Ad` to `Present` and `Petition` so we don't get
+// bitten by this again
+.aod_content
   clear: left
   display: block
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,12 +11,18 @@ class User < ActiveRecord::Base
   has_many :ads, foreign_key: :user_owner, dependent: :destroy
   has_many :comments, foreign_key: :user_owner, dependent: :destroy
 
-  has_many :friendships
+  has_many :friendships, dependent: :destroy
+  has_many :incoming_friendships, foreign_key: :friend_id,
+                                  class_name: 'Friendship',
+                                  dependent: :destroy
   has_many :friends, through: :friendships
 
   has_many :receipts, foreign_key: :receiver_id, dependent: :destroy
 
   has_many :blockings, foreign_key: :blocker_id, dependent: :destroy
+  has_many :received_blockings, foreign_key: :blocked_id,
+                                class_name: 'Blocking',
+                                dependent: :destroy
   has_many :dismissals, dependent: :destroy
 
   has_many :started_conversations,

--- a/app/views/ads/_ad.html.erb
+++ b/app/views/ads/_ad.html.erb
@@ -1,4 +1,4 @@
-<%= link_to adslug_path(ad, ad.slug), class: 'ad_content' do %>
+<%= link_to adslug_path(ad, ad.slug), class: 'aod_content' do %>
   <% if ad.image.exists? %>
     <div class="ad_list_image">
       <%= image_tag ad.image.url(:thumb), title: ad.filtered_title,

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -224,6 +224,7 @@ ca:
     delete_ad: Esborrar anunci
     delete_if_delivered: Si has regalat aquest anunci, et recomanem que en lloc d'esborrar-ho marquis com lliurat. Així l'anunci comptabilitzarà en les teves estadístiques de regals i potser aquestes estadístiques en un futur siguin utilitzades per proporcionar beneficis als més regaladores.
     delete_if_not_delivered: Si per contra has regalat l'objecte per un altre mitjà, l'has venut o has canviat d'opinió i ja no el vols regalar, endavant.
+    delete_sure: Segur que vols donar-te de baixa? Tots teu contingut serà esborrat de manera permanent.
     delivered: lliurat
     developers: desenvolupadors
     didn_t_receive_confirmation_instructions: No has rebut les instruccions de confirmació?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -225,6 +225,7 @@ en:
     delete_ad: Delete ad
     delete_if_delivered: If you have given away this ad, we recommend that you mark it as delivered instead. By doing that, the ad will be counted in your stats, and those stats might be used in the future to provide some benefits to the most generous people.
     delete_if_not_delivered: If you have actually given the ad away by other means, you've sold it or you've just changed your mind and you no longer want to give it away, go ahead!
+    delete_sure: Are you sure you want cancel your account? All your content will be permanently deleted.
     delivered: delivered
     developers: developers
     didn_t_receive_confirmation_instructions: Didn't receive the confirmation's instructions?

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -225,6 +225,7 @@ es:
     delete_ad: Borrar anuncio
     delete_if_delivered: Si has regalado este anuncio, te recomendamos que en lugar de borrarlo lo marques como entregado. Así el anuncio contabilizará en tus estadísticas de regalos y quizá estas estadísticas en un futuro sean utilizadas para proporcionar beneficios a los más regaladores.
     delete_if_not_delivered: Si por el contrario has regalado el objeto por otro medio, lo has vendido o has cambiado de opinión y ya no lo quieres regalar, adelante.
+    delete_sure: ¿Seguro que quieres darte de baja? Todo tu contenido será borrado de manera permanente.
     delivered: entregado
     developers: desarrolladores
     didn_t_receive_confirmation_instructions: "¿No has recibido las instrucciones de confirmación?"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -225,6 +225,7 @@ fr:
     delete_ad: Supprimer ad
     delete_if_delivered: 
     delete_if_not_delivered: 
+    delete_sure: Êtes-vous sûr que vous voulez vous désabonner? Tout votre contenu sera définitivement supprimé.
     delivered: dévoué
     developers: développeurs
     didn_t_receive_confirmation_instructions: Vous avez pas reçu les instructions de confirmation?

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -228,6 +228,7 @@ gl:
     delete_ad: Eliminar anuncio
     delete_if_delivered: 
     delete_if_not_delivered: 
+    delete_sure: Está seguro de que quere cancelar a subscrición? Todo o seu contido será eliminado permanentemente.
     delivered: dedicado
     developers: desarrolladores
     didn_t_receive_confirmation_instructions: 

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -225,6 +225,7 @@ it:
     delete_ad: Cancellare annuncio
     delete_if_delivered: Se hai regalato l'oggetto, raccomandiamo di cambiare lo stato a consegnato. Cosí l'annucio è contabilizato nelle tue statistiche e magari queste statistiche verrano usate nel future per fornire vantaggi ai migliori regalatori.
     delete_if_not_delivered: Se per contra hai regalato l'oggetto per altri mezzi oppure l'hai venduto o hai cambiato idea e non lo vuoi più regalare, vai avanti!
+    delete_sure: Sei sicuro che voui cancellare il tuo account? Tutto il tuo contenuto verrá cancellato in modo permanente.
     delivered: consegnato
     developers: svilupatori
     didn_t_receive_confirmation_instructions: Non hai ricevuto le istruzione di conferma?

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -225,6 +225,7 @@ pt:
     delete_ad: Apagar anúncio
     delete_if_delivered: 
     delete_if_not_delivered: 
+    delete_sure: Tem certeza de que deseja cancelar a inscrição? Todo o seu conteúdo será apagado permanentemente.
     delivered: entregado
     developers: desenvolvedores
     didn_t_receive_confirmation_instructions: Você não recebeu instruções de confirmação?

--- a/test/integration/profile_edition_and_removal_test.rb
+++ b/test/integration/profile_edition_and_removal_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class ProfileEditionTest < ActionDispatch::IntegrationTest
+class ProfileEditionAndRemovalTest < ActionDispatch::IntegrationTest
   include Warden::Test::Helpers
 
   before do
@@ -34,6 +34,13 @@ class ProfileEditionTest < ActionDispatch::IntegrationTest
     assert_text message
     assert_equal 'terec@example.com', User.first.email
     assert_equal 'terfo@example.com', User.first.unconfirmed_email
+  end
+
+  it 'allows account deletion' do
+    visit edit_user_registration_path
+    click_link 'Cancelar mi cuenta'
+
+    assert_text 'Fue grato tenerte con nosotros. Tu cuenta fue cancelada.'
   end
 
   private

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -127,4 +127,10 @@ class UserTest < ActiveSupport::TestCase
 
     assert_difference(-> { Comment.count }, -1) { @user.destroy }
   end
+
+  test 'associated blockings are deleted when user is deleted' do
+    create(:blocking, blocker: @user)
+
+    assert_difference(-> { Blocking.count }, -1) { @user.destroy }
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -133,4 +133,22 @@ class UserTest < ActiveSupport::TestCase
 
     assert_difference(-> { Blocking.count }, -1) { @user.destroy }
   end
+
+  test 'associated incoming blockings are deleted when user is deleted' do
+    create(:blocking, blocked: @user)
+
+    assert_difference(-> { Blocking.count }, -1) { @user.destroy }
+  end
+
+  test 'associated friendships are deleted when user is deleted' do
+    create(:friendship, user: @user)
+
+    assert_difference(-> { Friendship.count }, -1) { @user.destroy }
+  end
+
+  test 'associated incoming friendships are deleted when user is deleted' do
+    create(:friendship, friend: @user)
+
+    assert_difference(-> { Friendship.count }, -1) { @user.destroy }
+  end
 end

--- a/test/support/desktop_integration.rb
+++ b/test/support/desktop_integration.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'support/web_mocking'
-
 Capybara.register_driver :poltergeist_desktop do |app|
   Capybara::Poltergeist::Driver.new(app, window_size: [1366, 768],
                                          url_whitelist: ['127.0.0.1'])

--- a/test/support/mobile_integration.rb
+++ b/test/support/mobile_integration.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'support/web_mocking'
-
 Capybara.register_driver :poltergeist_mobile do |app|
   Capybara::Poltergeist::Driver.new(app, window_size: [320, 480],
                                          url_whitelist: ['127.0.0.1'])


### PR DESCRIPTION
Several hotfixes.

* Removal of some accounts crashing.
* Accessing resource pages in admin crashing.
* Listing getting hidden by AdBlock.