### PR TITLE
Add OpenGraph information to ad page

### DIFF
--- a/app/helpers/seo_helper.rb
+++ b/app/helpers/seo_helper.rb
@@ -21,6 +21,32 @@ module SeoHelper
     tag :meta, name: 'robots', content: content_for(:robots)
   end
 
+  def meta_open_graph
+    safe_join([meta_og_title, meta_og_type, meta_og_url, meta_og_image])
+  end
+
+  def meta_og_title
+    tag :meta, property: 'og:title', content: content_for(:title)
+  end
+
+  def meta_og_type
+    tag :meta, property: 'og:type', content: 'article'
+  end
+
+  def meta_og_url
+    tag :meta, property: 'og:url', content: canonical_url
+  end
+
+  def meta_og_image
+    content = if content_for?(:og_image)
+                content_for(:og_image)
+              else
+                asset_url('nolotiro_logo.png')
+              end
+
+    tag :meta, property: 'og:image', content: content
+  end
+
   def rel_canonical
     tag :link, rel: 'canonical', href: canonical_url
   end

--- a/app/views/ads/show.html.erb
+++ b/app/views/ads/show.html.erb
@@ -16,6 +16,8 @@
   </div>
 <% end %>
 
+<% content_for(:og_image, asset_url(@ad.image.url)) if @ad.image.exists? %>
+
 <div class="main-row">
   <div class="col-md-7 col-sm-7">
     <div class="default_header_section">

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -14,6 +14,8 @@
   <%= yield(:meta_extra) %>
 <% end %>
 
+<%= meta_open_graph %>
+
 <meta name='viewport' content='width=device-width, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no' />
 
 <%= rel_canonical %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= locale %>">
+<html prefix="og:https://ogp.me/ns#" lang="<%= locale %>">
   <head>
     <%= render 'layouts/head' %>
   </head>


### PR DESCRIPTION
Fixes #445.

Nolotiro's development will be steady for a few weeks, let's at least get this in so we can do a better job in social networks even when the platform is not getting improvements. Specifically, this unblocks some content we want to publish in Facebook but it's getting wrong images.