### PR TITLE
More SEO fixes

### DIFF
--- a/app/helpers/path_helper.rb
+++ b/app/helpers/path_helper.rb
@@ -12,6 +12,22 @@ module PathHelper
   end
 
   def canonical_url
-    url_for(params.merge(only_path: false))
+    return base_with_locale(params[:locale]) if home_path? || listall_give_path?
+
+    url_for(params.merge(locale: params[:locale], only_path: false))
+  end
+
+  def home_path?
+    return true if current_page?('/')
+
+    I18n.available_locales.any? { |locale| current_page?("/#{locale}") }
+  end
+
+  def listall_give_path?
+    request.path =~ %r{/listall/ad_type/give\Z}
+  end
+
+  def base_with_locale(locale)
+    [request.base_url, locale].compact.join('/')
   end
 end

--- a/app/helpers/path_helper.rb
+++ b/app/helpers/path_helper.rb
@@ -8,7 +8,9 @@ module PathHelper
   end
 
   def localized_url(locale)
-    url_for(params.merge(locale: locale, only_path: false))
+    request.original_url
+           .chomp('/')
+           .sub(base_with_locale(params[:locale]), base_with_locale(locale))
   end
 
   def canonical_url

--- a/app/helpers/path_helper.rb
+++ b/app/helpers/path_helper.rb
@@ -6,4 +6,12 @@ module PathHelper
 
     ads_woeid_path(current_woeid, type: type, status: status)
   end
+
+  def localized_url(locale)
+    url_for(params.merge(locale: locale, only_path: false))
+  end
+
+  def canonical_url
+    url_for(params.merge(only_path: false))
+  end
 end

--- a/app/helpers/seo_helper.rb
+++ b/app/helpers/seo_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module SeoHelper
+  include PathHelper
+
   def page_title
     content_tag(:title, "#{content_for(:title)} - nolotiro.org")
   end
@@ -33,15 +35,5 @@ module SeoHelper
     end
 
     x_default + safe_join(alternates)
-  end
-
-  private
-
-  def localized_url(locale)
-    url_for(params.merge(locale: locale, only_path: false))
-  end
-
-  def canonical_url
-    url_for(params.merge(only_path: false))
   end
 end

--- a/app/views/ads/show.html.erb
+++ b/app/views/ads/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :meta_title, @ad.meta_title %>
+<%= content_for :title, @ad.meta_title %>
 
 <%= content_for :meta_description do %>
   <%= t('nlt.meta_description_ad', title: @ad.filtered_title,

--- a/test/integration/alternate_urls_test.rb
+++ b/test/integration/alternate_urls_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AlternateUrlsTest < ActionDispatch::IntegrationTest
+  it 'sets alternate locales for all give ads page without locale' do
+    visit ads_listall_path(locale: nil, type: 'give')
+
+    assert_alternates_for '/ad/listall/ad_type/give'
+  end
+
+  it 'sets alternate locales for all give ads page with locale' do
+    visit ads_listall_path(locale: 'es', type: 'give')
+
+    assert_alternates_for '/ad/listall/ad_type/give'
+  end
+
+  it 'sets alternate locales for home page without locale' do
+    visit ''
+
+    assert_alternates_for '/'
+  end
+
+  it 'sets alternate locales for home page with locale' do
+    visit '/es'
+
+    assert_alternates_for '/'
+  end
+
+  it 'sets alternate locales for home page with trailing slash' do
+    visit '/'
+
+    assert_alternates_for '/'
+  end
+
+  it 'sets alternate locales for urls without locale in other pages' do
+    visit ads_listall_path(locale: nil, type: 'want')
+
+    assert_alternates_for '/ad/listall/ad_type/want'
+  end
+
+  it 'sets alternate locales for urls with locale in other pages' do
+    visit ads_listall_path(locale: 'es', type: 'want')
+
+    assert_alternates_for '/ad/listall/ad_type/want'
+  end
+
+  private
+
+  def assert_alternates_for(path)
+    url = if path == '/'
+            Capybara.current_host
+          else
+            "#{Capybara.current_host}#{path}"
+          end
+
+    assert_alternate url, 'x-default'
+
+    I18n.available_locales.each do |locale|
+      with_locale = "#{Capybara.current_host}/#{locale}"
+      url = path == '/' ? with_locale : "#{with_locale}#{path}"
+
+      assert_alternate url, locale
+    end
+  end
+
+  def assert_alternate(url, locale)
+    assert_selector \
+      :xpath,
+      "//link[@rel='alternate'][@href='#{url}'][@hreflang='#{locale}']",
+      visible: false
+  end
+end

--- a/test/integration/canonical_urls_test.rb
+++ b/test/integration/canonical_urls_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CanonicalUrlsTest < ActionDispatch::IntegrationTest
+  it 'canonical for all ads page is home page' do
+    visit ads_listall_path(locale: nil, type: 'give')
+
+    assert_canonical Capybara.current_host
+  end
+
+  it 'canonical for all give ads page keeps locale' do
+    visit ads_listall_path(locale: 'es', type: 'give')
+
+    assert_canonical "#{Capybara.current_host}/es"
+  end
+
+  it 'canonical for home page without trailing slash is itself' do
+    visit ''
+
+    assert_canonical Capybara.current_host
+  end
+
+  it 'canonical for home page with trailing slash is itself wihtout slash' do
+    visit '/'
+
+    assert_canonical Capybara.current_host
+  end
+
+  it 'canonical for home page keeps locale' do
+    visit '/es'
+
+    assert_canonical "#{Capybara.current_host}/es"
+  end
+
+  it 'canonical for other pages is a self-reference' do
+    visit ads_listall_path(locale: nil, type: 'want')
+
+    assert_canonical "#{Capybara.current_host}/ad/listall/ad_type/want"
+  end
+
+  it 'canonical for other pages keeps locale' do
+    visit ads_listall_path(locale: 'es', type: 'want')
+
+    assert_canonical "#{Capybara.current_host}/es/ad/listall/ad_type/want"
+  end
+
+  private
+
+  def assert_canonical(url)
+    assert_selector \
+      :xpath, "//link[@rel='canonical'][@href='#{url}']", visible: false
+  end
+end


### PR DESCRIPTION
* After today's refactorings, ad page title had been lost.
* Fix some bad alternate & canonical `<link>` tags, and add tests to keep this stuff always working.