### PR TITLE
Ordering issues

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -14,6 +14,20 @@ ActiveAdmin.register User do
   scope 'Legítimos', :legitimate, default: true
   scope 'Baneados', :banned
 
+  controller do
+    def find_collection
+      super(except: :sorting)
+    end
+
+    def scoped_collection
+      if current_scope.scope_method == :legitimate
+        super.order(created_at: :desc)
+      else
+        super.order(banned_at: :desc)
+      end
+    end
+  end
+
   filter :username
   filter :email
   filter :confirmed_at
@@ -73,6 +87,9 @@ ActiveAdmin.register User do
     column(:username) { |user| link_to user.username, admin_user_path(user) }
     column :email
     column :confirmed_at
+
+    column(:banned_at) if current_scope.scope_method == :banned
+
     column :last_sign_in_ip
     column :last_sign_in_at
     column :ads_count

--- a/app/controllers/ads_controller.rb
+++ b/app/controllers/ads_controller.rb
@@ -36,7 +36,7 @@ class AdsController < ApplicationController
   def show
     @comment = @ad.comments.build
     @ad.increment_readed_count!
-    @comments = policy_scope(@ad.comments).includes(:user)
+    @comments = policy_scope(@ad.comments).includes(:user).oldest_first
   end
 
   def edit

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -18,6 +18,8 @@ class Comment < ActiveRecord::Base
 
   scope :recent, -> { includes(:ad, :user).order(created_at: :desc).limit(30) }
 
+  scope :oldest_first, -> { order(created_at: :asc) }
+
   def body
     ApplicationController.helpers.escape_privacy_data(self[:body])
   end

--- a/test/integration/posting_comments_test.rb
+++ b/test/integration/posting_comments_test.rb
@@ -32,4 +32,14 @@ class PostingCommentsTest < ActionDispatch::IntegrationTest
 
     assert_no_selector '.comment', text: 'Tiene ruedas?'
   end
+
+  test 'comments are displayed oldest to newest' do
+    create(:comment, ad: @ad, body: 'Araña?', created_at: 12.days.ago)
+    create(:comment, ad: @ad, body: 'No, gato', created_at: 1.minute.ago)
+    mocking_yahoo_woeid_info(@ad.woeid_code) { visit ad_path(@ad) }
+
+    assert_selector '.comments h5:first-of-type', text: 'Comentarios'
+    assert_selector '.comments div:first-of-type', text: 'Araña?'
+    assert_selector '.comments div:nth-of-type(2)', text: 'No, gato'
+  end
 end


### PR DESCRIPTION
Fixes a couple of ordering issues:

* Comments didn't have any ordering enforce, so sometimes they would be displayed in a bad order.
* In the administration console, sort legitimate user list by registration date and banned user list by banning date. 