### PR TITLE
Duplicate content SEO issues

### DIFF
--- a/app/admin/ad.rb
+++ b/app/admin/ad.rb
@@ -85,7 +85,7 @@ ActiveAdmin.register Ad do
   end
 
   action_item :view, only: :show do
-    link_to 'Ver en la web', ad_path(ad)
+    link_to 'Ver en la web', adslug_path(ad, slug: ad.slug)
   end
 
   action_item :move, only: :show do

--- a/app/admin/comment.rb
+++ b/app/admin/comment.rb
@@ -32,6 +32,6 @@ ActiveAdmin.register Comment, as: 'AaComment' do
   end
 
   action_item :view, only: :show do
-    link_to 'Ver en la web', ad_path(aa_comment.ad)
+    link_to 'Ver en la web', adslug_path(aa_comment.ad, slug: aa_comment.ad.slug)
   end
 end

--- a/app/controllers/ads_controller.rb
+++ b/app/controllers/ads_controller.rb
@@ -4,7 +4,7 @@ class AdsController < ApplicationController
   include StringUtils
 
   before_action :set_ad, except: [:new, :create, :index]
-  before_action :authenticate_user!, except: [:index, :show]
+  before_action :authenticate_user!, except: [:index, :legacy_show, :show]
 
   def new
     if current_user.woeid.nil?
@@ -31,6 +31,10 @@ class AdsController < ApplicationController
     else
       render 'new'
     end
+  end
+
+  def legacy_show
+    redirect_to adslug_path(@ad, slug: @ad.slug), status: :moved_permanently
   end
 
   def show
@@ -79,13 +83,9 @@ class AdsController < ApplicationController
 
   def destroy_redirect_path
     previous_path = session.delete(:return_to)
-    return previous_path unless previous_path_destroyed?(previous_path)
+    return previous_path unless previous_path == ad_friendly_path
 
     listads_user_path(@ad.user)
-  end
-
-  def previous_path_destroyed?(previous_path)
-    [ad_friendly_path, ad_path(@ad)].include?(previous_path)
   end
 
   def ad_friendly_path

--- a/app/controllers/ads_controller.rb
+++ b/app/controllers/ads_controller.rb
@@ -38,9 +38,13 @@ class AdsController < ApplicationController
   end
 
   def show
-    @comment = @ad.comments.build
-    @ad.increment_readed_count!
-    @comments = policy_scope(@ad.comments).includes(:user).oldest_first
+    if @ad.slug != params[:slug]
+      redirect_to adslug_path(@ad, slug: @ad.slug), status: :moved_permanently
+    else
+      @comment = @ad.comments.build
+      @ad.increment_readed_count!
+      @comments = policy_scope(@ad.comments).includes(:user).oldest_first
+    end
   end
 
   def edit

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -16,7 +16,7 @@ class CommentsController < ApplicationController
       flash[:alert] = t('nlt.comments.flash_ko')
     end
 
-    redirect_to @ad
+    redirect_to adslug_path(@ad, slug: @ad.slug)
   end
 
   private

--- a/app/policies/ad_policy.rb
+++ b/app/policies/ad_policy.rb
@@ -9,6 +9,10 @@ class AdPolicy < ApplicationPolicy
     user && (record.user == user && record.bumpable?)
   end
 
+  def legacy_show?
+    show?
+  end
+
   def change_status?
     user && record.give? && record.user == user
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,12 +24,15 @@ NolotiroOrg::Application.routes.draw do
 
       # FIXME: type on ads#create instead of params
       # FIXME: nolotirov2 legacy - redirect from /es/ad/create
-      resources :ads, path: 'ad', path_names: { new: 'create' }, except: :index do
+      resources :ads, path: 'ad',
+                      path_names: { new: 'create' },
+                      except: [:index, :show] do
         resources :comments, only: :create
       end
 
       constraints(AdConstraint.new) do
         scope '/ad' do
+          get '/:id', to: 'ads#legacy_show'
           get '/:id/:slug', to: 'ads#show', as: 'adslug'
           get '/edit/id/:id', to: 'ads#edit', as: 'ads_edit'
           post '/bump/id/:id', to: 'ads#bump', as: 'ads_bump'

--- a/test/controllers/ads_controller_test.rb
+++ b/test/controllers/ads_controller_test.rb
@@ -59,38 +59,6 @@ class AdsControllerTest < ActionController::TestCase
     end
   end
 
-  test 'only ad owner should bump ads' do
-    @ad.update!(published_at: 6.days.ago)
-    sign_in @user
-    post :bump, id: @ad
-
-    assert_equal 6.days.ago.to_date, @ad.reload.published_at.to_date
-    assert_response :redirect
-    assert_redirected_to root_path
-  end
-
-  test 'should not bump ads too recent' do
-    @ad.update!(user_owner: @user.id, published_at: 4.days.ago)
-    sign_in @user
-    post :bump, id: @ad
-
-    assert_equal 4.days.ago.to_date, @ad.reload.published_at.to_date
-    assert_response :redirect
-    assert_redirected_to root_path
-  end
-
-  test 'should bump adds old enough' do
-    original_path = ads_woeid_path(@user.woeid, type: @ad.type)
-    request.env['HTTP_REFERER'] = original_path
-    @ad.update!(user_owner: @user.id, published_at: 6.days.ago)
-    sign_in @user
-    post :bump, id: @ad
-
-    assert_equal Time.zone.now.to_date, @ad.reload.published_at.to_date
-    assert_response :redirect
-    assert_redirected_to original_path
-  end
-
   test 'should not edit any ad as normal user' do
     @ad.update!(user_owner: @admin.id)
     sign_in @user

--- a/test/controllers/ads_controller_test.rb
+++ b/test/controllers/ads_controller_test.rb
@@ -68,6 +68,18 @@ class AdsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'redirects to new slugged URL after title changes' do
+    old_slug = @ad.slug
+    @ad.update!(title: 'My new title, mistyped something')
+
+    mocking_yahoo_woeid_info(@ad.woeid_code) do
+      get :show, id: @ad.id, slug: old_slug
+
+      assert_response :redirect
+      assert_redirected_to adslug_path(@ad, slug: @ad.slug)
+    end
+  end
+
   test 'should not edit any ad as normal user' do
     @ad.update!(user_owner: @admin.id)
     sign_in @user

--- a/test/controllers/ads_controller_test.rb
+++ b/test/controllers/ads_controller_test.rb
@@ -53,9 +53,18 @@ class AdsControllerTest < ActionController::TestCase
 
   test 'should show ad' do
     mocking_yahoo_woeid_info(@ad.woeid_code) do
-      get :show, id: @ad.id
+      get :show, id: @ad.id, slug: @ad.slug
 
       assert_response :success
+    end
+  end
+
+  test 'redirects to slugged version from non-slugged one' do
+    mocking_yahoo_woeid_info(@ad.woeid_code) do
+      get :legacy_show, id: @ad.id
+
+      assert_response :redirect
+      assert_redirected_to adslug_path(@ad, slug: @ad.slug)
     end
   end
 

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -23,6 +23,6 @@ class CommentsControllerTest < ActionController::TestCase
       post :create, ad_id: @ad.id, comment: { body: 'hola mundo' }
     end
     assert_response :redirect
-    assert_redirected_to ad_path(@ad)
+    assert_redirected_to adslug_path(@ad, slug: @ad.slug)
   end
 end

--- a/test/integration/ad_edition_and_removal_test.rb
+++ b/test/integration/ad_edition_and_removal_test.rb
@@ -43,14 +43,14 @@ class AdEditionAndRemovalTest < AuthenticatedTest
   end
 
   it 'properly deletes ads from show page and redirects to user list' do
-    initial_path = ad_path(@ad)
+    initial_path = adslug_path(@ad, slug: @ad.slug)
 
     assert_destroy_ad_from(initial_path)
     assert_equal listads_user_path(@current_user), current_path
   end
 
   it 'properly deletes ads as an admin and redirects to user list' do
-    initial_path = ad_path(@ad)
+    initial_path = adslug_path(@ad, slug: @ad.slug)
 
     logout
     login_as create(:admin)

--- a/test/integration/ad_edition_and_removal_test.rb
+++ b/test/integration/ad_edition_and_removal_test.rb
@@ -35,13 +35,6 @@ class AdEditionAndRemovalTest < AuthenticatedTest
     assert_equal initial_path, current_path
   end
 
-  it 'properly deletes ads from slug show page and redirects to user list' do
-    initial_path = adslug_path(@ad, slug: @ad.slug)
-
-    assert_destroy_ad_from(initial_path)
-    assert_equal listads_user_path(@current_user), current_path
-  end
-
   it 'properly deletes ads from show page and redirects to user list' do
     initial_path = adslug_path(@ad, slug: @ad.slug)
 

--- a/test/integration/ad_management_test.rb
+++ b/test/integration/ad_management_test.rb
@@ -2,9 +2,11 @@
 
 require 'test_helper'
 require 'integration/concerns/authenticated_test'
+require 'support/ads'
 require 'support/web_mocking'
 
 class AdManagementTest < AuthenticatedTest
+  include AdTestHelpers
   include WebMocking
 
   it 'can have pictures of 5 megabytes or less' do
@@ -28,28 +30,20 @@ class AdManagementTest < AuthenticatedTest
   end
 
   it 'republishes ads' do
-    ad = create(:ad, user: @current_user, published_at: 6.days.ago)
-
-    mocking_yahoo_woeid_info(ad.woeid_code) do
-      visit ad_path(ad)
-      click_link 'Republica este anuncio'
-    end
+    visit_ad_page(create(:ad, user: @current_user, published_at: 6.days.ago))
+    click_link 'Republica este anuncio'
 
     assert_text 'Anuncio republicado'
   end
 
   it 'changes ad status' do
-    ad = create(:ad, :available, user: @current_user)
+    visit_ad_page(create(:ad, :available, user: @current_user))
 
-    mocking_yahoo_woeid_info(ad.woeid_code) do
-      visit ad_path(ad)
+    assert_no_selector 'a', text: 'Marcar disponible'
+    assert_selector 'a', text: 'Marcar reservado'
+    assert_selector 'a', text: 'Marcar entregado'
 
-      assert_no_selector 'a', text: 'Marcar disponible'
-      assert_selector 'a', text: 'Marcar reservado'
-      assert_selector 'a', text: 'Marcar entregado'
-
-      click_link 'Marcar reservado'
-    end
+    click_link 'Marcar reservado'
 
     assert_text 'Anuncio reservado'
     assert_selector 'a', text: 'Marcar disponible'

--- a/test/integration/banning_test.rb
+++ b/test/integration/banning_test.rb
@@ -2,10 +2,10 @@
 
 require 'test_helper'
 require 'integration/concerns/authenticated_test'
-require 'support/web_mocking'
+require 'support/ads'
 
 class BanningTest < AuthenticatedTest
-  include WebMocking
+  include AdTestHelpers
 
   it 'automatically kicks out banned users' do
     mocking_yahoo_woeid_info(@current_user.woeid) do
@@ -23,7 +23,7 @@ class BanningTest < AuthenticatedTest
   it 'hides ads from banned users' do
     ad = create(:ad)
     ad.user.ban!
-    mocking_yahoo_woeid_info(ad.woeid_code) { visit ad_path(ad) }
+    visit_ad_page(ad)
 
     assert_no_text ad.body
   end

--- a/test/integration/links_for_ads_test.rb
+++ b/test/integration/links_for_ads_test.rb
@@ -1,36 +1,26 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require 'support/web_mocking'
+require 'support/ads'
 
 class LinksForAds < ActionDispatch::IntegrationTest
-  include WebMocking
+  include AdTestHelpers
 
   it 'shows message link in available ads' do
-    within_ad_page(create(:ad, :available)) do
-      assert_text 'Envía un mensaje privado al anunciante'
-    end
+    visit_ad_page(create(:ad, :available))
+
+    assert_text 'Envía un mensaje privado al anunciante'
   end
 
   it 'does not show message link in booked ads' do
-    within_ad_page(create(:ad, :booked)) do
-      assert_no_text 'Envía un mensaje privado al anunciante'
-    end
+    visit_ad_page(create(:ad, :booked))
+
+    assert_no_text 'Envía un mensaje privado al anunciante'
   end
 
   it 'does not show message link in delivered ads' do
-    within_ad_page(create(:ad, :delivered)) do
-      assert_no_text 'Envía un mensaje privado al anunciante'
-    end
-  end
+    visit_ad_page(create(:ad, :delivered))
 
-  private
-
-  def within_ad_page(ad)
-    mocking_yahoo_woeid_info(ad.woeid_code) do
-      visit ad_path(ad)
-
-      yield
-    end
+    assert_no_text 'Envía un mensaje privado al anunciante'
   end
 end

--- a/test/integration/posting_comments_test.rb
+++ b/test/integration/posting_comments_test.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require 'support/web_mocking'
+require 'support/ads'
 
 class PostingCommentsTest < ActionDispatch::IntegrationTest
   include Warden::Test::Helpers
-  include WebMocking
+  include AdTestHelpers
 
   before { @ad = create(:ad, comments_enabled: true) }
 
   test 'users need to login before posting a comment' do
-    mocking_yahoo_woeid_info(@ad.woeid_code) { visit ad_path(@ad) }
+    visit_ad_page(@ad)
 
     refute_selector '.comments > form'
   end
 
   test 'comments can be posted by logged in users' do
     login_as @ad.user
-    mocking_yahoo_woeid_info(@ad.woeid_code) { visit ad_path(@ad) }
+    visit_ad_page(@ad)
     fill_in 'Tu comentario', with: 'No tiene ruedas'
     click_button 'Enviar'
 
@@ -28,7 +28,7 @@ class PostingCommentsTest < ActionDispatch::IntegrationTest
   test 'comments from spammers are not listed' do
     comment = create(:comment, ad: @ad, body: 'Tiene ruedas?')
     comment.user.ban!
-    mocking_yahoo_woeid_info(@ad.woeid_code) { visit ad_path(@ad) }
+    visit_ad_page(@ad)
 
     assert_no_selector '.comment', text: 'Tiene ruedas?'
   end

--- a/test/integration/user_blockings_test.rb
+++ b/test/integration/user_blockings_test.rb
@@ -2,9 +2,11 @@
 
 require 'test_helper'
 require 'integration/concerns/authenticated_test'
+require 'support/ads'
 require 'support/web_mocking'
 
 class UserBlockingsTest < AuthenticatedTest
+  include AdTestHelpers
   include WebMocking
 
   before { @other = create(:user, username: 'other') }
@@ -46,7 +48,7 @@ class UserBlockingsTest < AuthenticatedTest
   it 'does not show ad page when visitor is blocked' do
     ad = create(:ad, user: @other)
     create(:blocking, blocker: @other, blocked: @current_user)
-    mocking_yahoo_woeid_info(ad.woeid_code) { visit ad_path(ad) }
+    visit_ad_page(ad)
 
     assert_access_denied
   end
@@ -54,10 +56,10 @@ class UserBlockingsTest < AuthenticatedTest
   it 'does not show send message link in ad page when blocked by user' do
     ad = create(:ad, user: @other)
     create(:blocking, blocker: @current_user, blocked: @other)
-    mocking_yahoo_woeid_info(ad.woeid_code) { visit ad_path(ad) }
+    visit_ad_page(ad)
 
     assert_no_selector 'a', text: 'envía un mensaje privado a other'
-    assert_equal ad_path(ad), current_path
+    assert_equal adslug_path(ad, slug: ad.slug), current_path
   end
 
   it 'does not show conversations with her when blocked by user' do
@@ -71,10 +73,10 @@ class UserBlockingsTest < AuthenticatedTest
   it 'does not show comment textarea when visitor blocking ad author' do
     ad = create(:ad, user: @other, comments_enabled: true)
     create(:blocking, blocker: @current_user, blocked: @other)
-    mocking_yahoo_woeid_info(ad.woeid_code) { visit ad_path(ad) }
+    visit_ad_page(ad)
 
     refute_selector '.comment_form'
-    assert_equal ad_path(ad), current_path
+    assert_equal adslug_path(ad, slug: ad.slug), current_path
   end
 
   private

--- a/test/support/ads.rb
+++ b/test/support/ads.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'support/web_mocking'
+
+module AdTestHelpers
+  include WebMocking
+
+  def visit_ad_page(ad)
+    mocking_yahoo_woeid_info(ad.woeid_code) do
+      visit adslug_path(ad, slug: ad.slug)
+    end
+  end
+end


### PR DESCRIPTION
More SEO issues. Right now the slugged and non-slugged versions of the ad page are different URLs pointing to the same content. Google doesn't like this.

I deprecated the non-slugged version and added redirects to the slugged one.

In addition, I detected another issue: the slugged URLs start giving 404s if the title is changed, we should redirect this old urls the their new version.