### PR TITLE
Save ip of autobanned users

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -5,7 +5,7 @@ class RegistrationsController < Devise::RegistrationsController
     if omniauth_registration? || verify_recaptcha
       super
 
-      resource.ban! if resource.valid? && suspicious_ip?
+      spam_control(request.remote_ip)
     else
       build_resource
       clean_up_passwords(resource)
@@ -23,8 +23,8 @@ class RegistrationsController < Devise::RegistrationsController
 
   private
 
-  def suspicious_ip?
-    User.suspicious?(request.remote_ip)
+  def spam_control(ip)
+    resource.ban_and_save_ip!(ip) if resource.valid? && User.suspicious?(ip)
   end
 
   def omniauth_registration?

--- a/app/models/concerns/baneable.rb
+++ b/app/models/concerns/baneable.rb
@@ -43,6 +43,10 @@ module Baneable
     update!(banned_at: Time.zone.now)
   end
 
+  def ban_and_save_ip!(ip)
+    update!(banned_at: Time.zone.now, last_sign_in_ip: ip)
+  end
+
   def legitimate?
     banned_at.nil?
   end

--- a/test/integration/registration_test.rb
+++ b/test/integration/registration_test.rb
@@ -39,5 +39,6 @@ class RegistrationTest < ActionDispatch::IntegrationTest
     click_button 'Regístrate'
     assert_equal 2, User.count
     refute_nil User.last.banned_at
+    assert_equal '1.1.1.1', User.last.last_sign_in_ip
   end
 end


### PR DESCRIPTION
Autobanning recidivist IPs is working quite well, but we should actually save the IP of the user being banned so we can more easily detect false positives.