### PR TITLE
Bigger new conversation textarea

### DIFF
--- a/app/assets/stylesheets/_common.sass.erb
+++ b/app/assets/stylesheets/_common.sass.erb
@@ -280,7 +280,7 @@ form.searchbox
   padding: 10px 15px
 
 /**
- * Ads
+ * Ads.
 
 .profile-info
   font-size: 1.3em
@@ -414,7 +414,7 @@ form.searchbox
   margin-bottom: 14px
 
 /**
- * Flash & error messages
+ * Flash & error messages.
 
 .flash-msg
   width: 100%
@@ -453,7 +453,7 @@ form.searchbox
     color: #264409
 
 /**
- * Messages
+ * Messages.
 
 .mail-list
   tr:last-child
@@ -676,7 +676,7 @@ form.searchbox
   padding: 0
 
 /**
- * Pagination
+ * Pagination.
 
 .pagination
   border-radius: 0
@@ -715,7 +715,7 @@ form.searchbox
       border-color: #000033
 
 /**
- * Footer
+ * Footer.
 
 .page_footer
   position: absolute
@@ -727,7 +727,7 @@ form.searchbox
   color: #999
 
 /**
- * Tabs
+ * Tabs.
 
 .nlt-tabs
   @extend .nav-tabs
@@ -742,7 +742,7 @@ form.searchbox
       color: $navbar-default-link-active-color
 
 /**
- * Misc
+ * Misc.
 
 #cookie-bar
   z-index: 99999

--- a/app/assets/stylesheets/_defaults.sass
+++ b/app/assets/stylesheets/_defaults.sass
@@ -71,6 +71,7 @@ input[type=radio]
 textarea
   width: 95%
   height: 250px
+  min-height: 250px
   padding: 5px
   resize: none
 

--- a/app/views/conversations/_reply.html.erb
+++ b/app/views/conversations/_reply.html.erb
@@ -9,10 +9,10 @@
           <%= errors_for(message) %>
 
           <div class="form-group">
-            <%= text_area_tag :body,
-                              params[:body],
-                              size: '80x3',
-                              maxlength: 1500 %>
+            <%= text_area_tag :body, params[:body], size: '80x3',
+                                                    maxlength: 1500,
+                                                    required: true,
+                                                    class: 'form-control' %>
 
             <p class="help-block">
               <%= t 'conversations.new.body_max' %>

--- a/test/integration/concerns/messaging_tests.rb
+++ b/test/integration/concerns/messaging_tests.rb
@@ -45,7 +45,9 @@ module MessagingTests
     send_message(subject: 'hola, user2', body: 'How you doing?')
     send_message(body: '')
 
-    assert_text 'Mensaje no puede estar en blanco'
+    # Check HTML5 validator is present since this driver understand it and does
+    # not submit the form
+    assert_selector :xpath, "//textarea[@required='required']"
   end
 
   def test_replies_to_conversation

--- a/test/integration/conversations_test.rb
+++ b/test/integration/conversations_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'integration/concerns/messaging'
+
+class ConversationsTest < ActionDispatch::IntegrationTest
+  include Warden::Test::Helpers
+  include Messaging
+
+  def setup
+    super
+
+    user1 = create(:user, username: 'user1')
+    user2 = create(:user, username: 'user2')
+
+    login_as user1
+
+    visit new_conversation_path(recipient_id: user2.id)
+  end
+
+  def teardown
+    super
+
+    logout
+  end
+
+  def test_shows_errors_when_replying_to_conversation_with_empty_message
+    send_message(subject: 'hola, user2', body: 'How you doing?')
+    send_message(body: '')
+
+    assert_text 'Mensaje no puede estar en blanco'
+  end
+end


### PR DESCRIPTION
New message textarea's height was too small. Now it's ok and it's consistent with conversation reply textarea.