### PR TITLE
Contact author in petitions

### DIFF
--- a/app/policies/conversation_policy.rb
+++ b/app/policies/conversation_policy.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class ConversationPolicy < ApplicationPolicy
-  def index
-    user
-  end
-
   def create?
     sender && recipient && user == sender && no_blockings?
   end

--- a/app/views/ads/show.html.erb
+++ b/app/views/ads/show.html.erb
@@ -56,7 +56,7 @@
         <%= render "stats", comments_count: @comments.size,
                             readed_count: @ad.readed_count %>
 
-        <% if @ad.available? &&
+        <% if (@ad.want? || @ad.available?) &&
               (current_user.nil? || current_user.whitelisting?(@ad.user)) %>
           <div class="ad_contact">
             <%= t('nlt.are_you_interested') %>

--- a/app/views/ads/show.html.erb
+++ b/app/views/ads/show.html.erb
@@ -60,12 +60,13 @@
               (current_user.nil? || current_user.whitelisting?(@ad.user)) %>
           <div class="ad_contact">
             <%= t('nlt.are_you_interested') %>
+            <% title = t('nlt.send_a_message', user: @ad.user.username) %>
 
             <%= link_to new_conversation_path(recipient_id: @ad.user_owner,
                                               subject: @ad.slug),
                         class: "world_link" do %>
-              <%= t('nlt.send_a_message') %>
-              <%= image_tag "email_send.png", alt: t('nlt.send_a_message') %>
+              <%= title.to_s %>
+              <%= image_tag "email_send.png", alt: title %>
             <% end %>
           </div>
         <% end %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -337,7 +337,7 @@ ca:
       no_ads_message_html: No hi ha anuncis que coincideixin amb la cerca <b>%{q}</b>.
     searching_on_html: Buscant <i>%{q}</i> a
     send: Enviar
-    send_a_message: "+ Envia un missatge privat a l'anunciant"
+    send_a_message: "+ Envia un missatge privat a %{user}"
     share_this_ad: Comparteix aquest anunci
     sign_in: Accedir
     sign_in_with_provider: Inicia sessió amb %{provider}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -338,7 +338,7 @@ en:
       no_ads_message_html: There are no matching ads with your search <b>%{q}</b>.
     searching_on_html: Searching <i>%{q}</i> on
     send: Send
-    send_a_message: "+ Send a private message to this user"
+    send_a_message: "+ Send a private message to %{user}"
     share_this_ad: Share this ad
     sign_in: Sign in
     sign_in_with_provider: Sign in with %{provider}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -338,7 +338,7 @@ es:
       no_ads_message_html: No hay anuncios que coincidan con la búsqueda <b>%{q}</b> en la ubicación.
     searching_on_html: Buscando <i>%{q}</i> en
     send: Enviar
-    send_a_message: "+ Envía un mensaje privado al anunciante"
+    send_a_message: "+ Envía un mensaje privado a %{user}"
     share_this_ad: Comparte este anuncio
     sign_in: Acceder
     sign_in_with_provider: Inicia sesión con %{provider}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -340,7 +340,7 @@ fr:
       no_ads_message_html: Aucune annonce correspondant à la recherche <b>%{q}</b>.
     searching_on_html: Regarder <i>%{q}</i> en
     send: Envoyer
-    send_a_message: "+ Envoyer un message privé à l'annonceur"
+    send_a_message: "+ Envoyer un message privé à %{user}"
     share_this_ad: Diffuse cette annonce
     sign_in: S'identifier
     sign_in_with_provider: Connexion avec %{provider}

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -343,7 +343,7 @@ gl:
       no_ads_message_html: 
     searching_on_html: 
     send: 
-    send_a_message: 
+    send_a_message: "+ Envía unha mensaxe a %{user}"
     share_this_ad: Comparte este anuncio
     sign_in: Acceder
     sign_in_with_provider: Entrar co %{provider}

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -344,7 +344,7 @@ it:
       no_ads_message_html: Non ci sono annunci che corrispondano alla ricerca <b>%{q}</b>.
     searching_on_html: Cercando <i>%{q}</i> in
     send: Inviare
-    send_a_message: "+ Invia un messaggio privato al annunciante"
+    send_a_message: "+ Invia un messaggio privato a %{user}"
     share_this_ad: Condividi questo annuncio
     sign_in: Login
     sign_in_with_provider: Accedi con %{provider}

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -338,7 +338,7 @@ pt:
       no_ads_message_html: Não existem anúncios que concordem com sua búsqueda <b>%{q}</b>.
     searching_on_html: Buscando <i>%{q}</i> em
     send: Enviar
-    send_a_message: "+ Envia uma mensagem privada ao anunciante"
+    send_a_message: "+ Envia uma mensagem privada ao %{user}"
     share_this_ad: Compartilha este anúncio
     sign_in: Accesar
     sign_in_with_provider: Fazer login com %{provider}

--- a/test/integration/links_for_ads_test.rb
+++ b/test/integration/links_for_ads_test.rb
@@ -7,26 +7,32 @@ class LinksForAds < ActionDispatch::IntegrationTest
   include AdTestHelpers
 
   it 'shows message link in available ads' do
-    visit_ad_page(create(:ad, :available))
+    visit_ad_page_with_type(:available)
 
-    assert_text 'Envía un mensaje privado al anunciante'
+    assert_text 'Envía un mensaje privado a lisa'
   end
 
   it 'does not show message link in booked ads' do
-    visit_ad_page(create(:ad, :booked))
+    visit_ad_page_with_type(:booked)
 
-    assert_no_text 'Envía un mensaje privado al anunciante'
+    assert_no_text 'Envía un mensaje privado a lisa'
   end
 
   it 'does not show message link in delivered ads' do
-    visit_ad_page(create(:ad, :delivered))
+    visit_ad_page_with_type(:delivered)
 
-    assert_no_text 'Envía un mensaje privado al anunciante'
+    assert_no_text 'Envía un mensaje privado a lisa'
   end
 
   it 'shows message link in petition ads' do
-    visit_ad_page(create(:ad, :want))
+    visit_ad_page_with_type(:want)
 
-    assert_text 'Envía un mensaje privado al anunciante'
+    assert_text 'Envía un mensaje privado a lisa'
+  end
+
+  private
+
+  def visit_ad_page_with_type(type)
+    visit_ad_page(create(:ad, type, user: create(:user, username: 'lisa')))
   end
 end

--- a/test/integration/links_for_ads_test.rb
+++ b/test/integration/links_for_ads_test.rb
@@ -23,4 +23,10 @@ class LinksForAds < ActionDispatch::IntegrationTest
 
     assert_no_text 'Envía un mensaje privado al anunciante'
   end
+
+  it 'shows message link in petition ads' do
+    visit_ad_page(create(:ad, :want))
+
+    assert_text 'Envía un mensaje privado al anunciante'
+  end
 end


### PR DESCRIPTION
* Fixes one bug where contact link wouldn't be displayed for petitions.
* Changes the label of the link to include "username" instead of "anunciante".