### PR TITLE
Improve republication

### DIFF
--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -84,10 +84,6 @@ class Ad < ActiveRecord::Base
     last_ad_publication.strftime('%d%m%y%H%M%s')
   end
 
-  def reset_readed_count!
-    update_column(:readed_count, 1)
-  end
-
   def increment_readed_count!
     Ad.increment_counter(:readed_count, id)
   end
@@ -129,8 +125,6 @@ class Ad < ActiveRecord::Base
   end
 
   def bump
-    touch(:published_at)
-
-    reset_readed_count!
+    update!(published_at: Time.zone.now, readed_count: 1)
   end
 end

--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -129,5 +129,6 @@ class Ad < ActiveRecord::Base
     attributes[:status] = :available if give?
 
     update!(attributes)
+    comments.destroy_all
   end
 end

--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -42,7 +42,7 @@ class Ad < ActiveRecord::Base
 
   validates_attachment_size :image, in: 0.megabytes..5.megabytes
 
-  scope :recent, -> { Ad.includes(:user).recent_first.limit(90) }
+  scope :recent, -> { includes(:user).recent_first.limit(90) }
 
   scope :by_woeid_code, ->(woeid_code) do
     return all unless woeid_code.present?
@@ -78,14 +78,14 @@ class Ad < ActiveRecord::Base
   end
 
   def self.cache_digest
-    last_ad_publication = Ad.maximum(:published_at)
+    last_ad_publication = maximum(:published_at)
     return '0' * 20 unless last_ad_publication
 
     last_ad_publication.strftime('%d%m%y%H%M%s')
   end
 
   def increment_readed_count!
-    Ad.increment_counter(:readed_count, id)
+    self.class.increment_counter(:readed_count, id)
   end
 
   def move!

--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -121,10 +121,13 @@ class Ad < ActiveRecord::Base
   end
 
   def bumpable?
-    published_at <= 5.days.ago
+    published_at <= 5.days.ago && !delivered?
   end
 
   def bump
-    update!(published_at: Time.zone.now, readed_count: 1)
+    attributes = { published_at: Time.zone.now, readed_count: 1 }
+    attributes[:status] = :available if give?
+
+    update!(attributes)
   end
 end

--- a/lib/tasks/comments.rake
+++ b/lib/tasks/comments.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :comments do
+  desc 'Deletes comments made before bumping ads'
+  task remove_prior_to_bumps: :environment do
+    target = Comment.joins(:ad).where('comments.created_at < ads.published_at')
+
+    STDOUT.print "About to delete #{target.size} comments. Continue? (y/n)"
+    abort unless STDIN.gets.chomp == 'y'
+
+    target.destroy_all
+  end
+end

--- a/test/integration/ad_management_test.rb
+++ b/test/integration/ad_management_test.rb
@@ -31,7 +31,7 @@ class AdManagementTest < AuthenticatedTest
 
   it 'republishes ads' do
     visit_ad_page(create(:ad, user: @current_user, published_at: 6.days.ago))
-    click_link 'Republica este anuncio'
+    click_link_by_label('Republicar')
 
     assert_text 'Anuncio republicado'
   end
@@ -39,7 +39,7 @@ class AdManagementTest < AuthenticatedTest
   it 'does not republish ads if not owner' do
     visit_ad_page(create(:ad, user: create(:user), published_at: 6.days.ago))
 
-    assert_no_selector 'a', text: 'Republica este anuncio'
+    assert_no_selector 'a', text: 'Republicar'
   end
 
   it 'does not republish ads if not owner (direct request)' do
@@ -55,7 +55,7 @@ class AdManagementTest < AuthenticatedTest
   it 'does not bump ads too recent' do
     visit_ad_page(create(:ad, user: @current_user, published_at: 4.days.ago))
 
-    assert_no_selector 'a', text: 'Republica este anuncio'
+    assert_no_selector 'a', text: 'Republicar'
   end
 
   it 'does not bump ads too recent (direct request)' do
@@ -103,6 +103,10 @@ class AdManagementTest < AuthenticatedTest
   end
 
   private
+
+  def click_link_by_label(text)
+    find('a', text: text).click
+  end
 
   def submit_ad_form(file_path: nil, title: 'File')
     visit new_ad_path

--- a/test/integration/ad_management_test.rb
+++ b/test/integration/ad_management_test.rb
@@ -29,11 +29,38 @@ class AdManagementTest < AuthenticatedTest
     end
   end
 
-  it 'republishes ads' do
-    visit_ad_page(create(:ad, user: @current_user, published_at: 6.days.ago))
+  it 'republishes available ads' do
+    ad = create(:ad, :available, user: @current_user, published_at: 6.days.ago)
+    visit_ad_page(ad)
     click_link_by_label('Republicar')
 
     assert_text 'Anuncio republicado'
+  end
+
+  it 'republishes booked ads and changes status' do
+    ad = create(:ad, :booked, user: @current_user, published_at: 6.days.ago)
+    visit_ad_page(ad)
+    click_link_by_label('Republicar')
+
+    assert_text 'Anuncio republicado'
+    assert_equal true, ad.reload.available?
+  end
+
+  it 'does not republish delivered ads' do
+    ad = create(:ad, :delivered, user: @current_user, published_at: 6.days.ago)
+    visit_ad_page(ad)
+
+    assert_no_selector 'a', text: 'Republicar'
+  end
+
+  it 'does not republish delivered ads (direct request)' do
+    ad = create(:ad, :delivered, user: create(:user), published_at: 6.days.ago)
+    original_path = ads_woeid_path(ad.woeid_code, type: 'give')
+    post ads_bump_path(ad), {}, 'HTTP_REFERER' => original_path
+
+    assert_equal 6.days.ago.to_date, ad.reload.published_at.to_date
+    assert_response :redirect
+    assert_redirected_to original_path
   end
 
   it 'does not republish ads if not owner' do

--- a/test/models/ad_test.rb
+++ b/test/models/ad_test.rb
@@ -117,10 +117,9 @@ class AdTest < ActiveSupport::TestCase
   end
 
   test 'ad body stores emoji' do
-    body = 'Pantalones cortos para el veranito que se vene! 😀 '
-    ad = create(:ad, body: body)
+    ad = create(:ad, body: 'Pantalones cortos para el veranito! 😀 ')
 
-    assert_equal body, ad.body
+    assert_equal 'Pantalones cortos para el veranito! 😀 ', ad.body
   end
 
   test 'ad bumping refreshes publication date' do
@@ -138,10 +137,9 @@ class AdTest < ActiveSupport::TestCase
   end
 
   test 'associated comments are deleted when ad is deleted' do
-    ad = create(:ad)
-    create(:comment, ad: ad)
+    comment = create(:comment)
 
-    assert_difference(-> { Comment.count }, -1) { ad.destroy }
+    assert_difference(-> { Comment.count }, -1) { comment.ad.destroy }
   end
 
   test '.by_title ignores invalid bytes sequences' do

--- a/test/models/ad_test.rb
+++ b/test/models/ad_test.rb
@@ -136,6 +136,12 @@ class AdTest < ActiveSupport::TestCase
     assert_equal 1, ad.readed_count
   end
 
+  test 'ad bumping deletes associated comments' do
+    comment = create(:comment)
+
+    assert_difference(-> { Comment.count }, -1) { comment.ad.bump }
+  end
+
   test 'associated comments are deleted when ad is deleted' do
     comment = create(:comment)
 


### PR DESCRIPTION
* Fixes #458.
* Also removes old comments when republishing ads since the fact that the republished ad has comments prior to its publication date is confusing.