### PR TITLE
Fixes weird crash in ad removal

### DIFF
--- a/app/controllers/ads_controller.rb
+++ b/app/controllers/ads_controller.rb
@@ -87,7 +87,9 @@ class AdsController < ApplicationController
 
   def destroy_redirect_path
     previous_path = session.delete(:return_to)
-    return previous_path unless previous_path == ad_friendly_path
+    unless previous_path.nil? || previous_path == ad_friendly_path
+      return previous_path
+    end
 
     listads_user_path(@ad.user)
   end


### PR DESCRIPTION
To reproduce, open two different ad edit pages in different tabs, and
click then delete ad button of each one. The second submission will
result in this crash.

It seems hard to add a test for this, so I'll just fix and hope it
doesn't regress.

Fixes https://err.nolotiro.org/apps/571de5807a440000b2000005/problems/5810a03b9efd7201cb000004