### PR TITLE
No spam in rankings

### DIFF
--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -66,7 +66,11 @@ class Ad < ActiveRecord::Base
   end
 
   def self.rank_by(*attributes)
-    give.group(*attributes).order('n_ads DESC').limit(ranking_size)
+    give
+      .from_legitimate_authors
+      .group(*attributes)
+      .order('n_ads DESC')
+      .limit(ranking_size)
   end
 
   def self.full_ranking?(rank_scope)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,7 +98,8 @@ class User < ActiveRecord::Base
   end
 
   def self.build_rank(ads_scope)
-    joins(:ads)
+    legitimate
+      .joins(:ads)
       .merge(ads_scope.rank_by(:id, :username, :user_owner))
       .pluck(:id, :username, 'COUNT(user_owner) as n_ads')
   end

--- a/test/models/rankings_test.rb
+++ b/test/models/rankings_test.rb
@@ -31,10 +31,24 @@ class RankingsTest < ActiveSupport::TestCase
                  User.top_overall
   end
 
+  test 'top overall excludes banned users' do
+    create(:ad, user: @user3)
+    @user1.ban!
+
+    assert_equal [[2, 'user2', 2], [3, 'user3', 1]], User.top_overall
+  end
+
   test "top last week gives last week's top publishers" do
     create(:ad, user: @user3, published_at: 8.days.ago)
 
     assert_equal [[1, 'user1', 3], [2, 'user2', 2]], User.top_last_week
+  end
+
+  test 'top last week excludes banned users' do
+    create(:ad, user: @user3, published_at: 8.days.ago)
+    @user1.ban!
+
+    assert_equal [[2, 'user2', 2]], User.top_last_week
   end
 
   test 'top locations returns cities with most ads' do

--- a/test/models/rankings_test.rb
+++ b/test/models/rankings_test.rb
@@ -62,6 +62,18 @@ class RankingsTest < ActiveSupport::TestCase
     end
   end
 
+  test 'top locations excludes ads by banned users' do
+    mocking_yahoo_woeid_info(766_273) do
+      results = Ad.top_locations
+      @user1.ban!
+
+      assert_equal 1, results.length
+      assert_equal 766_273, results.first.woeid_code
+      assert_equal 'Madrid', results.first.woeid_name_short
+      assert_equal 2, results.first.n_ads
+    end
+  end
+
   test 'top overall city with all users ads in the same city' do
     assert_equal [[1, 'user1', 3], [2, 'user2', 2]],
                  User.top_city_overall(766_273)


### PR DESCRIPTION
After a "black Friday" in regard to SPAM, some users have sneaked in to our rankings. They shouldn't be there.