### PR TITLE
Petitions particularities

### DIFF
--- a/app/models/ad_ranking.rb
+++ b/app/models/ad_ranking.rb
@@ -30,7 +30,7 @@ class AdRanking
   private
 
   def cache_digest
-    last_ad_publication = Ad.maximum(:published_at)
+    last_ad_publication = Ad.give.maximum(:published_at)
     return '0' * 20 unless last_ad_publication
 
     last_ad_publication.strftime('%d%m%y%H%M%s')

--- a/app/views/ads/show.html.erb
+++ b/app/views/ads/show.html.erb
@@ -65,7 +65,7 @@
             <%= link_to new_conversation_path(recipient_id: @ad.user_owner,
                                               subject: @ad.slug),
                         class: "world_link" do %>
-              <%= title.to_s %>
+              <%= "+ #{title}" %>
               <%= image_tag "email_send.png", alt: title %>
             <% end %>
           </div>

--- a/app/views/ads/show.html.erb
+++ b/app/views/ads/show.html.erb
@@ -59,8 +59,13 @@
         <% if (@ad.want? || @ad.available?) &&
               (current_user.nil? || current_user.whitelisting?(@ad.user)) %>
           <div class="ad_contact">
-            <%= t('nlt.are_you_interested') %>
-            <% title = t('nlt.send_a_message', user: @ad.user.username) %>
+            <% if @ad.available? %>
+              <%= t('nlt.are_you_interested') %>
+              <% title = t('nlt.send_a_message', user: @ad.user.username) %>
+            <% else %>
+              <%= t('nlt.do_you_have_it') %>
+              <% title = t('nlt.give_it_to', user: @ad.user.username) %>
+            <% end %>
 
             <%= link_to new_conversation_path(recipient_id: @ad.user_owner,
                                               subject: @ad.slug),

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -229,6 +229,7 @@ ca:
     delivered: lliurat
     developers: desenvolupadors
     didn_t_receive_confirmation_instructions: No has rebut les instruccions de confirmació?
+    do_you_have_it: Ho tens?
     edit: Editar
     edit_this_ad: Edita aquest anunci
     faq:
@@ -258,6 +259,7 @@ ca:
     gift_on: regal en %{woeid}
     gifts: regals
     give: regal
+    give_it_to: Regala'l a %{user}
     hello_to: Hola %{recipient},
     here: aquí
     home_title: anuncis de regals nous i de segona mà

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -337,7 +337,7 @@ ca:
       no_ads_message_html: No hi ha anuncis que coincideixin amb la cerca <b>%{q}</b>.
     searching_on_html: Buscant <i>%{q}</i> a
     send: Enviar
-    send_a_message: "+ Envia un missatge privat a %{user}"
+    send_a_message: Envia un missatge privat a %{user}
     share_this_ad: Comparteix aquest anunci
     sign_in: Accedir
     sign_in_with_provider: Inicia sessió amb %{provider}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -338,7 +338,7 @@ en:
       no_ads_message_html: There are no matching ads with your search <b>%{q}</b>.
     searching_on_html: Searching <i>%{q}</i> on
     send: Send
-    send_a_message: "+ Send a private message to %{user}"
+    send_a_message: Send a private message to %{user}
     share_this_ad: Share this ad
     sign_in: Sign in
     sign_in_with_provider: Sign in with %{provider}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -230,6 +230,7 @@ en:
     delivered: delivered
     developers: developers
     didn_t_receive_confirmation_instructions: Didn't receive the confirmation's instructions?
+    do_you_have_it: Do you have it?
     edit_this_ad: Edit this ad
     edit: Edit
     faq:
@@ -259,6 +260,7 @@ en:
     gift_on: gift on %{woeid}
     gifts: presents
     give: gift
+    give_it_to: Give it away to %{user}
     hello_to: Hello %{recipient},
     here: here
     home_title: new and second hand gift's ads

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -338,7 +338,7 @@ es:
       no_ads_message_html: No hay anuncios que coincidan con la búsqueda <b>%{q}</b> en la ubicación.
     searching_on_html: Buscando <i>%{q}</i> en
     send: Enviar
-    send_a_message: "+ Envía un mensaje privado a %{user}"
+    send_a_message: Envía un mensaje privado a %{user}
     share_this_ad: Comparte este anuncio
     sign_in: Acceder
     sign_in_with_provider: Inicia sesión con %{provider}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -230,6 +230,7 @@ es:
     delivered: entregado
     developers: desarrolladores
     didn_t_receive_confirmation_instructions: "¿No has recibido las instrucciones de confirmación?"
+    do_you_have_it: ¿Lo tienes?
     edit_this_ad: Edita este anuncio
     edit: Editar
     faq:
@@ -259,6 +260,7 @@ es:
     gift_on: regalo en %{woeid}
     gifts: regalos
     give: regalo
+    give_it_to: Regálaselo a %{user}
     hello_to: Hola %{recipient},
     here: aquí
     home_title: anuncios de regalos nuevos y de segunda mano

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -230,6 +230,7 @@ fr:
     delivered: dévoué
     developers: développeurs
     didn_t_receive_confirmation_instructions: Vous avez pas reçu les instructions de confirmation?
+    do_you_have_it: Est-ce vous l'avez?
     edit_this_ad: Modifier cette annonce
     edit: Modifier
     faq:
@@ -259,6 +260,7 @@ fr:
     gift_on: cadeau en %{woeid}
     gifts: cadeaux
     give: cadeau
+    give_it_to: Contacter %{user}
     hello_to: Salut %{recipient},
     here: ici
     home_title: annonces de cadeaux neuves et d'occasion

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -340,7 +340,7 @@ fr:
       no_ads_message_html: Aucune annonce correspondant à la recherche <b>%{q}</b>.
     searching_on_html: Regarder <i>%{q}</i> en
     send: Envoyer
-    send_a_message: "+ Envoyer un message privé à %{user}"
+    send_a_message: Envoyer un message privé à %{user}
     share_this_ad: Diffuse cette annonce
     sign_in: S'identifier
     sign_in_with_provider: Connexion avec %{provider}

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -233,6 +233,7 @@ gl:
     delivered: dedicado
     developers: desarrolladores
     didn_t_receive_confirmation_instructions: 
+    do_you_have_it: O tes?
     edit_this_ad: Edita este anuncio
     edit: Editar
     faq:
@@ -262,6 +263,7 @@ gl:
     gift_on: regalo en %{woeid}
     gifts: regalos
     give: regalo
+    give_it_to: Regálaselo a %{user}
     hello_to: Ola %{recipient},
     here: aquí
     home_title: 

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -343,7 +343,7 @@ gl:
       no_ads_message_html: 
     searching_on_html: 
     send: 
-    send_a_message: "+ Envía unha mensaxe a %{user}"
+    send_a_message: Envía unha mensaxe a %{user}
     share_this_ad: Comparte este anuncio
     sign_in: Acceder
     sign_in_with_provider: Entrar co %{provider}

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -344,7 +344,7 @@ it:
       no_ads_message_html: Non ci sono annunci che corrispondano alla ricerca <b>%{q}</b>.
     searching_on_html: Cercando <i>%{q}</i> in
     send: Inviare
-    send_a_message: "+ Invia un messaggio privato a %{user}"
+    send_a_message: Invia un messaggio privato a %{user}
     share_this_ad: Condividi questo annuncio
     sign_in: Login
     sign_in_with_provider: Accedi con %{provider}

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -230,6 +230,7 @@ it:
     delivered: consegnato
     developers: svilupatori
     didn_t_receive_confirmation_instructions: Non hai ricevuto le istruzione di conferma?
+    do_you_have_it: Ce l'hai?
     edit_this_ad: Editare questo annuncio
     edit: Editare
     faq:
@@ -261,6 +262,7 @@ it:
     gift_on: regalo in %{woeid}
     gifts: regali
     give: regalo
+    give_it_to: Regalalo a %{user}
     hello_to: Ciao %{recipient},
     here: qui
     home_title: 'annunci di regali nuovi e di seconda mano '

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -230,6 +230,7 @@ pt:
     delivered: entregado
     developers: desenvolvedores
     didn_t_receive_confirmation_instructions: Você não recebeu instruções de confirmação?
+    do_you_have_it: Tem isso?
     edit_this_ad: Edita este anúncio
     edit: Editar
     faq:
@@ -259,6 +260,7 @@ pt:
     gift_on: dou presente em %{woeid}
     gifts: presentes
     give: presente
+    give_it_to: Da um presente para %{user}
     hello_to: Olá %{recipient},
     here: aqui
     home_title: anúncios de presentes novos e de segunda mão

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -338,7 +338,7 @@ pt:
       no_ads_message_html: Não existem anúncios que concordem com sua búsqueda <b>%{q}</b>.
     searching_on_html: Buscando <i>%{q}</i> em
     send: Enviar
-    send_a_message: "+ Envia uma mensagem privada ao %{user}"
+    send_a_message: Envia uma mensagem privada ao %{user}
     share_this_ad: Compartilha este anúncio
     sign_in: Accesar
     sign_in_with_provider: Fazer login com %{provider}

--- a/test/integration/links_for_ads_test.rb
+++ b/test/integration/links_for_ads_test.rb
@@ -27,7 +27,7 @@ class LinksForAds < ActionDispatch::IntegrationTest
   it 'shows message link in petition ads' do
     visit_ad_page_with_type(:want)
 
-    assert_text 'Envía un mensaje privado a lisa'
+    assert_text 'Regálaselo a lisa'
   end
 
   private


### PR DESCRIPTION
Fixes #520.

Now for petitions we say "¿Lo tienes? Regálaselo a [nombre]".

It also tweaks rankings cache key so that new petition ads are ignored since rankings do not count those.