### PR TITLE
Send build notifications to a common mailbox [WIP]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,5 +48,6 @@ deploy:
   provider: script
   script: rvm $TRAVIS_RUBY_VERSION do bin/cap production deploy
   skip_cleanup: true
+
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,14 @@ env:
 
 language: ruby
 
+notifications:
+  email:
+    recipients:
+      - hola@nolotiro.org
+
+    on_success: always
+    on_failure: always
+
 rvm:
   - 2.3.4
 


### PR DESCRIPTION
Current behavior:

* Only me (or whoever authors the merge commit) gets notified about build (and thus deploy) status.
* Notifications are only sent "on_change". When the build gets broken or, once it's broken, when it gets fixed.

I think it's interesting to:

* Send notifications to a common e-mail address instead. Which one? hola at nolotiro? hola at alabs?
* Always send notifications, not only "on_change". So we all know new stuff has been deployed.

@andreslucena @iokese , thoughts?