### PR TITLE
Enable per-form CSFR tokens

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -8,9 +8,6 @@
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
-# Enable per-form CSRF tokens. Previous versions had false.
-Rails.application.config.action_controller.per_form_csrf_tokens = false
-
 # Enable origin-checking CSRF mitigation. Previous versions had false.
 Rails.application.config.action_controller.forgery_protection_origin_check = false
 


### PR DESCRIPTION
Start enabling Rails 5 default settings. This enables per-form CSFR tokens, a better default security setting.