### PR TITLE
Flip `to_time_preserves_timezone` config

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -16,7 +16,7 @@ Rails.application.config.action_controller.forgery_protection_origin_check = tru
 
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.
-ActiveSupport.to_time_preserves_timezone = false
+ActiveSupport.to_time_preserves_timezone = true
 
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = false


### PR DESCRIPTION
New way of handling timezones in time conversions.