### PR TITLE
Don't halt callbacks on returning false

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -22,4 +22,4 @@ ActiveSupport.to_time_preserves_timezone = true
 Rails.application.config.active_record.belongs_to_required_by_default = false
 
 # Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = true
+ActiveSupport.halt_callback_chains_on_return_false = false


### PR DESCRIPTION
Almost done here, this one enables not halting from callbacks when returning `false` from them.