### PR TITLE
Fix deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ group :test do
 end
 
 group :production, :staging do
-  gem 'airbrake', '~> 4.0' # exception notification
+  gem 'airbrake', '~> 5.0' # exception notification
 
   # @todo Add a performance monitoring tool
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,9 +54,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
-    airbrake (4.3.1)
-      builder
-      multi_json
+    airbrake (5.8.1)
+      airbrake-ruby (~> 1.8)
+    airbrake-ruby (1.8.0)
     airbrussh (1.3.0)
       sshkit (>= 1.6.1, != 1.7.0)
     arbre (1.1.1)
@@ -429,7 +429,7 @@ PLATFORMS
 
 DEPENDENCIES
   activeadmin (~> 1.0)
-  airbrake (~> 4.0)
+  airbrake (~> 5.0)
   bootstrap-sass (~> 3.3)
   brakeman-lib
   bullet

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
     airbrake (4.3.1)
       builder
       multi_json
-    airbrussh (1.2.0)
+    airbrussh (1.3.0)
       sshkit (>= 1.6.1, != 1.7.0)
     arbre (1.1.1)
       activesupport (>= 3.0.0)
@@ -88,7 +88,7 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
     byebug (9.0.6)
-    capistrano (3.8.0)
+    capistrano (3.8.2)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -96,7 +96,7 @@ GEM
     capistrano-bundler (1.2.0)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
-    capistrano-rails (1.2.3)
+    capistrano-rails (1.3.0)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
     capistrano-rbenv (2.1.1)
@@ -389,7 +389,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sshkit (1.13.1)
+    sshkit (1.14.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     temple (0.7.7)

--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -2,9 +2,8 @@
 
 if Rails.env.production? || Rails.env.staging?
   Airbrake.configure do |config|
-    config.api_key = ENV['AIRBRAKE_APIKEY']
-    config.host    = ENV['AIRBRAKE_HOST']
-    config.port    = ENV['AIRBRAKE_PORT'].to_i
-    config.secure  = config.port == 443
+    config.project_key = ENV['AIRBRAKE_APIKEY']
+    config.project_id = 1
+    config.host = ENV['AIRBRAKE_HOST']
   end
 end


### PR DESCRIPTION
Deployment of the Rails 5.1 PR failed because our airbrake version is not compatible. I tried the new version in the beta site and it works fine.