### PR TITLE
Bump airbrake to 6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ group :test do
 end
 
 group :production, :staging do
-  gem 'airbrake', '~> 5.0' # exception notification
+  gem 'airbrake', '~> 6.0' # exception notification
 
   # @todo Add a performance monitoring tool
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,9 +54,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
-    airbrake (5.8.1)
-      airbrake-ruby (~> 1.8)
-    airbrake-ruby (1.8.0)
+    airbrake (6.2.1)
+      airbrake-ruby (~> 2.3, >= 2.3.1)
+    airbrake-ruby (2.3.1)
     airbrussh (1.3.0)
       sshkit (>= 1.6.1, != 1.7.0)
     arbre (1.1.1)
@@ -429,7 +429,7 @@ PLATFORMS
 
 DEPENDENCIES
   activeadmin (~> 1.0)
-  airbrake (~> 5.0)
+  airbrake (~> 6.0)
   bootstrap-sass (~> 3.3)
   brakeman-lib
   bullet


### PR DESCRIPTION
This PR bumps airbrake to the latest version. Already tested in beta, works fine.