### PR TITLE
Remove page level ads from devise pages

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -47,11 +47,13 @@
 
 -->
 
-<script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<% unless no_advertising_allowed? %>
+  <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 
-<script>
-  (adsbygoogle = window.adsbygoogle || []).push({
-    google_ad_client: "ca-pub-5360961269901609",
-    enable_page_level_ads: true
-  });
-</script>
+  <script>
+    (adsbygoogle = window.adsbygoogle || []).push({
+      google_ad_client: "ca-pub-5360961269901609",
+      enable_page_level_ads: true
+    });
+  </script>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -65,11 +65,12 @@
 
     <div class="hide js-cookie-message"><%= t('nlt.cookie') %></div>
 
-    <script>
-      [].forEach.call(document.querySelectorAll('.adsbygoogle'), function(){
-        (adsbygoogle = window.adsbygoogle || []).push({});
-      });
-    </script>
-
+    <% unless no_advertising_allowed? %>
+      <script>
+        [].forEach.call(document.querySelectorAll('.adsbygoogle'), function(){
+          (adsbygoogle = window.adsbygoogle || []).push({});
+        });
+      </script>
+    <% end %>
   </body>
 </html>


### PR DESCRIPTION
I requested a review from google for their partial ad restriction and they said we still don't comply with their policy. I reviewed it again and they're right. We were still serving page level ads on content-less pages.

Hopefully this PR fixes that.