### PR TITLE
Revert email alias detection

### DIFF
--- a/app/models/concerns/baneable.rb
+++ b/app/models/concerns/baneable.rb
@@ -6,9 +6,6 @@
 module Baneable
   def self.prepended(base)
     base.class_eval do
-      before_validation :remove_dot_aliases, if: %i[email_changed? email_allows_dot_aliases?]
-      before_validation :remove_plus_aliases, if: %i[email_changed? email_allows_plus_aliases?]
-
       scope :legitimate, -> { where(banned_at: nil) }
       scope :banned, -> { where.not(banned_at: nil) }
       scope :recent_spammers, -> { where('banned_at >= ?', 3.months.ago) }
@@ -60,23 +57,5 @@ module Baneable
 
   def moderate!
     banned? ? unban! : ban!
-  end
-
-  private
-
-  def email_allows_dot_aliases?
-    email.match?(/@gmail.com\z/)
-  end
-
-  def email_allows_plus_aliases?
-    email.match?(/@(gmail|hotmail|outlook).com\z/)
-  end
-
-  def remove_dot_aliases
-    email.gsub!(/\A([^@]+)/) { |identifier| identifier.delete('.') }
-  end
-
-  def remove_plus_aliases
-    email.gsub!(/\+[^@]+/, '')
   end
 end

--- a/test/integration/registration_test.rb
+++ b/test/integration/registration_test.rb
@@ -9,13 +9,10 @@ class RegistrationTest < ActionDispatch::IntegrationTest
   before do
     visit root_path
     click_link 'nuevo usuario'
-    fill_in 'Tu email', with: 'nolotiro@example.com'
-    fill_in 'Elige tu contraseña', with: '111111'
-    fill_in 'Introduce tu contraseña', with: '111111'
-    fill_in 'Elige un nombre de usuario', with: 'nolotiro'
   end
 
   it 'sends a confirmation email' do
+    fill_registration_form(email: 'nolotiro@example.com')
     click_button 'Regístrate'
 
     assert_text <<~MSG
@@ -25,14 +22,25 @@ class RegistrationTest < ActionDispatch::IntegrationTest
   end
 
   it 'redirects to change city page after first login' do
+    fill_registration_form(email: 'nolotiro@example.com', password: '222222')
     click_button 'Regístrate'
     User.first.confirm
-    login('nolotiro@example.com', '111111')
+    login('nolotiro@example.com', '222222')
 
     assert_text 'Cambia tu ciudad'
   end
 
+  it 'allows login after registration' do
+    fill_registration_form(email: 'n.o.l.o.tiro@gmail.com', password: '333333')
+    click_button 'Regístrate'
+    User.first.confirm
+    login('n.o.l.o.tiro@gmail.com', '333333')
+
+    assert_text 'Has iniciado sesión'
+  end
+
   it 'automatically bans users registering from recently banned ips' do
+    fill_registration_form(email: 'nolotiro@example.com')
     create(:user, :recent_spammer, last_sign_in_ip: '1.1.1.1')
     page.driver.options[:headers] = { 'REMOTE_ADDR' => '1.1.1.1' }
 
@@ -40,5 +48,14 @@ class RegistrationTest < ActionDispatch::IntegrationTest
     assert_equal 2, User.count
     refute_nil User.last.banned_at
     assert_equal '1.1.1.1', User.last.last_sign_in_ip
+  end
+
+  private
+
+  def fill_registration_form(email:, password: '111111', username: 'nolotiro')
+    fill_in 'Tu email', with: email
+    fill_in 'Elige tu contraseña', with: password
+    fill_in 'Introduce tu contraseña', with: password
+    fill_in 'Elige un nombre de usuario', with: username
   end
 end

--- a/test/models/user_validation_test.rb
+++ b/test/models/user_validation_test.rb
@@ -57,29 +57,6 @@ class UserValidationTest < ActiveSupport::TestCase
     assert_equal 'larryfoster@example.com', user1.email
   end
 
-  test 'handles dot aliases' do
-    create(:user, email: 'gilitofresh@gmail.com')
-    create(:user, email: 'gilitofresh@hotmail.com')
-    create(:user, email: 'gilitofresh@outlook.com')
-
-    assert_not build(:user, email: 'gilito.fresh@gmail.com').valid?
-    assert_not build(:user, email: 'g.ilito.fresh@gmail.com').valid?
-    assert build(:user, email: 'gilito.fresh@hotmail.com').valid?
-    assert build(:user, email: 'g.ilito.fresh@hotmail.com').valid?
-    assert build(:user, email: 'gilito.fresh@outlook.com').valid?
-    assert build(:user, email: 'g.ilito.fresh@outlook.com').valid?
-  end
-
-  test 'handles plus aliases' do
-    create(:user, email: 'gilitofresh@gmail.com')
-    create(:user, email: 'gilitofresh@hotmail.com')
-    create(:user, email: 'gilitofresh@outlook.com')
-
-    assert_not build(:user, email: 'gilitofresh+17@gmail.com').valid?
-    assert_not build(:user, email: 'gilitofresh+17@hotmail.com').valid?
-    assert_not build(:user, email: 'gilitofresh+17@outlook.com').valid?
-  end
-
   test 'has passwords no shorter than 5 characters' do
     user1 = build(:user, password: '1234')
     assert_not user1.valid?


### PR DESCRIPTION
This PR reverts #560 since it's not that easy and it introduced some bugs. We need to ensure that the canonical version of the email is used everywhere. Particularly, when logging in. Added a regression test so that the next try doesn't hit these problems.