### PR TITLE
Bump redis-rack to 2.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,7 +330,7 @@ GEM
     redis-activesupport (5.0.2)
       activesupport (>= 3, < 6)
       redis-store (~> 1.3.0)
-    redis-rack (2.0.3)
+    redis-rack (2.0.4)
       rack (>= 1.5, < 3)
       redis-store (>= 1.2, < 2)
     redis-rails (5.0.2)


### PR DESCRIPTION
The previous version had a nasty bug where the `rake` executable would
be hijacked by it, causing using system wide since `rake` can't be
run...

My [decidim] tests were failing because of this... xD

See https://github.com/redis-store/redis-rack/pull/34.

[decidim]: https://github.com/decidim/decidim

